### PR TITLE
Use protoversion for containerd version

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.pedge.io/proto/version"
+
 	"google.golang.org/grpc"
 
 	"github.com/Sirupsen/logrus"
@@ -77,7 +79,7 @@ var daemonFlags = []cli.Flag{
 func main() {
 	app := cli.NewApp()
 	app.Name = "containerd"
-	app.Version = containerd.Version
+	app.Version = containerd.Version.VersionString()
 	app.Usage = Usage
 	app.Authors = authors
 	app.Flags = daemonFlags
@@ -201,6 +203,15 @@ func daemon(id, address, stateDir string, concurrency int, oom bool) error {
 	}
 	s := grpc.NewServer()
 	types.RegisterAPIServer(s, server.NewServer(sv))
+	protoversion.RegisterAPIServer(
+		s,
+		protoversion.NewAPIServer(
+			containerd.Version,
+			protoversion.APIServerOptions{
+				DisableLogging: true,
+			},
+		),
+	)
 	logrus.Debugf("GRPC API listen on %s", address)
 	return s.Serve(l)
 }

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -23,6 +23,10 @@ import (
 
 // TODO: parse flags and pass opts
 func getClient(ctx *cli.Context) types.APIClient {
+	return types.NewAPIClient(getClientConn(ctx))
+}
+
+func getClientConn(ctx *cli.Context) *grpc.ClientConn {
 	dialOpts := []grpc.DialOption{grpc.WithInsecure()}
 	dialOpts = append(dialOpts,
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
@@ -33,7 +37,7 @@ func getClient(ctx *cli.Context) types.APIClient {
 	if err != nil {
 		fatal(err.Error(), 1)
 	}
-	return types.NewAPIClient(conn)
+	return conn
 }
 
 var ContainersCommand = cli.Command{

--- a/ctr/main.go
+++ b/ctr/main.go
@@ -14,7 +14,7 @@ const Usage = `High performance container daemon cli`
 func main() {
 	app := cli.NewApp()
 	app.Name = "ctr"
-	app.Version = containerd.Version
+	app.Version = containerd.Version.VersionString()
 	app.Usage = Usage
 	app.Authors = []cli.Author{
 		{
@@ -37,6 +37,7 @@ func main() {
 		CheckpointCommand,
 		ContainersCommand,
 		EventsCommand,
+		VersionCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/ctr/version.go
+++ b/ctr/version.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"go.pedge.io/proto/version"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/containerd"
+)
+
+var VersionCommand = cli.Command{
+	Name:  "version",
+	Usage: "get the containerd version",
+	Action: func(context *cli.Context) {
+		serverVersion, err := protoversion.GetServerVersion(getClientConn(context))
+		if err != nil {
+			fatal(err.Error(), 1)
+		}
+		fmt.Printf("Client: %s\nServer: %s\n", containerd.Version.VersionString(), serverVersion.VersionString())
+	},
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,9 @@
 package containerd
 
-const Version = "0.0.4"
+import "go.pedge.io/proto/version"
+
+var Version = &protoversion.Version{
+	Major: 0,
+	Minor: 0,
+	Micro: 4,
+}


### PR DESCRIPTION
This is more a suggestion, if you actually wanted to use this, you'd probably want to copy proto/version into here, or I could rework it to have less default dependencies (right now it depends on a lot of my code that docker does not use ie https://go.pedge.io/protolog).

For my protobuf projects, I use a `Version` message for both client and server side versions. The setup is pretty simple - with the `version.API` service, there is both a `GetVersion` rpc, and a `GET /version` route using https://github.com/gengo/grpc-gateway. I use cobra instead of codegangsta/cli, so I just have https://github.com/peter-edge/go-proto/blob/master/client/protoclient.go to make the commands for me, but I do the same logic here for you.