### PR TITLE
Add dependency on the container build for steps doing "run"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ fmt:
 lint:
 	@golint ./... | grep -v vendor | grep -v .pb. | tee /dev/stderr
 
-shell:
+shell: dbuild
 	$(DOCKER_RUN) bash
 
 test: all validate


### PR DESCRIPTION
Make sure that the container is actually built before commands in the
Makefile that require doing `docker run` on the devel container.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>