### PR TITLE
 set default buildtags as 'runc' in Makefile will be more friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILDTAGS=libcontainer
+BUILDTAGS=runc
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach


### PR DESCRIPTION
To fellow what we described in README.md, we should set default runtime mode as runc, this will not misguide the new contributor and ensure our intention be more clearly.

Signed-off-by: Peng Zhouhu    <pengzhouhu@huawei.com>
