### PR TITLE
Chown stdio with proper user

### DIFF
--- a/linux/linux.go
+++ b/linux/linux.go
@@ -414,7 +414,11 @@ func (r *libcontainerRuntime) Create(id, bundlePath, consolePath string) (runtim
 			return nil, nil, err
 		}
 	} else {
-		i, err := process.InitializeIO(int(spec.Process.User.UID))
+		uid, err := config.HostUID()
+		if err != nil {
+			return nil, nil, err
+		}
+		i, err := process.InitializeIO(uid)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -449,7 +453,11 @@ func (r *libcontainerRuntime) StartProcess(ci runtime.Container, p specs.Process
 			return nil, nil, err
 		}
 	} else {
-		i, err := process.InitializeIO(int(p.User.UID))
+		uid, err := c.c.Config().HostUID()
+		if err != nil {
+			return nil, nil, err
+		}
+		i, err := process.InitializeIO(uid)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
If user namespace is used we should chown with a remapped ID.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>