### PR TITLE
Translate RootfsPropagation flags from spec to internal config

### DIFF
--- a/linux/linux.go
+++ b/linux/linux.go
@@ -560,6 +560,15 @@ func (r *libcontainerRuntime) createLibcontainerConfig(cgroupName, bundlePath st
 		}
 		config.Mounts = append(config.Mounts, r.createLibcontainerMount(bundlePath, mp.Path, m))
 	}
+
+	// Convert rootfs propagation flag
+	if rspec.Linux.RootfsPropagation != "" {
+		_, pflags, _ := parseMountOptions([]string{rspec.Linux.RootfsPropagation})
+		if len(pflags) == 1 {
+			config.RootPropagation = pflags[0]
+		}
+	}
+
 	if err := r.createDevices(rspec, config); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

---

This fixes an issue causing all shared volumes to be treated as slaves (i.e. inheriting the root value)