### PR TITLE
Add pause, resume, watch command to ctr

### DIFF
--- a/ctr/container.go
+++ b/ctr/container.go
@@ -48,6 +48,7 @@ var containersCommand = cli.Command{
 		execCommand,
 		killCommand,
 		listCommand,
+		pauseCommand,
 		startCommand,
 		statsCommand,
 	},
@@ -267,6 +268,26 @@ func attachStdio(s stdio) error {
 	}
 	go io.Copy(os.Stderr, stderrf)
 	return nil
+}
+
+var pauseCommand = cli.Command{
+	Name:  "pause",
+	Usage: "pause a container",
+	Action: func(context *cli.Context) {
+		id := context.Args().First()
+		if id == "" {
+			fatal("container id cannot be empty", 1)
+		}
+		c := getClient(context)
+		_, err := c.UpdateContainer(netcontext.Background(), &types.UpdateContainerRequest{
+			Id:     id,
+			Pid:    "init",
+			Status: "paused",
+		})
+		if err != nil {
+			fatal(err.Error(), 1)
+		}
+	},
 }
 
 var killCommand = cli.Command{

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -49,6 +49,7 @@ var containersCommand = cli.Command{
 		killCommand,
 		listCommand,
 		pauseCommand,
+		resumeCommand,
 		startCommand,
 		statsCommand,
 	},
@@ -283,6 +284,26 @@ var pauseCommand = cli.Command{
 			Id:     id,
 			Pid:    "init",
 			Status: "paused",
+		})
+		if err != nil {
+			fatal(err.Error(), 1)
+		}
+	},
+}
+
+var resumeCommand = cli.Command{
+	Name:  "resume",
+	Usage: "resume a paused container",
+	Action: func(context *cli.Context) {
+		id := context.Args().First()
+		if id == "" {
+			fatal("container id cannot be empty", 1)
+		}
+		c := getClient(context)
+		_, err := c.UpdateContainer(netcontext.Background(), &types.UpdateContainerRequest{
+			Id:     id,
+			Pid:    "init",
+			Status: "running",
 		})
 		if err != nil {
 			fatal(err.Error(), 1)


### PR DESCRIPTION
This adds 3 new commands to ctr:
 - pause: pause a container
 - resume: resume a container
 - watch: dump events matching a given container id or events for all containers if no id is provided