### PR TITLE
Refactor process.go for platform specific

### DIFF
--- a/runtime/process_linux.go
+++ b/runtime/process_linux.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"os"
+	"syscall"
+)
+
+func getExitPipe(path string) (*os.File, error) {
+	if err := syscall.Mkfifo(path, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+	// add NONBLOCK in case the other side has already closed or else
+	// this function would never return
+	return os.OpenFile(path, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
+}
+
+func getControlPipe(path string) (*os.File, error) {
+	if err := syscall.Mkfifo(path, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+	return os.OpenFile(path, syscall.O_RDWR|syscall.O_NONBLOCK, 0)
+}
+
+// Signal sends the provided signal to the process
+func (p *process) Signal(s os.Signal) error {
+	return syscall.Kill(p.pid, s.(syscall.Signal))
+}

--- a/runtime/process_windows.go
+++ b/runtime/process_windows.go
@@ -1,0 +1,19 @@
+package runtime
+
+import "os"
+
+// TODO Windows: Linux uses syscalls which don't map to Windows. Needs alternate mechanism
+func getExitPipe(path string) (*os.File, error) {
+	return nil, nil
+}
+
+// TODO Windows: Linux uses syscalls which don't map to Windows. Needs alternate mechanism
+func getControlPipe(path string) (*os.File, error) {
+	return nil, nil
+}
+
+// TODO Windows. Windows does not support signals. Need alternate mechanism
+// Signal sends the provided signal to the process
+func (p *process) Signal(s os.Signal) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@crosbymichael Refactoring of process.go to get closer to compiling on Windows. Windows will need alternate implementations as the Linux code uses implementations which are not available on Windows.