### PR TITLE
Add a new "live" Event type

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -168,6 +168,11 @@ func (s *Supervisor) Events(from time.Time) chan Event {
 			}
 		}
 	}
+	// Notify the client that from now on it's live events
+	c <- Event{
+		Type:      "live",
+		Timestamp: time.Now(),
+	}
 	return c
 }
 


### PR DESCRIPTION
This event type is used to notify consumers that everything following
are real-time events. This allow clients that request events from the
backlog to detect when those events have all been sent.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>