### PR TITLE
Send "live" event only if past events requested

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -169,11 +169,11 @@ func (s *Supervisor) Events(from time.Time) chan Event {
 				c <- e
 			}
 		}
-	}
-	// Notify the client that from now on it's live events
-	c <- Event{
-		Type:      "live",
-		Timestamp: time.Now(),
+		// Notify the client that from now on it's live events
+		c <- Event{
+			Type:      "live",
+			Timestamp: time.Now(),
+		}
 	}
 	return c
 }


### PR DESCRIPTION
This fixes a bug where the live events are recorded in the events log.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>