### PR TITLE
Getting ctr closer to compiling on Windows

### DIFF
--- a/api/grpc/server/server.go
+++ b/api/grpc/server/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/containerd/runtime"
+	"github.com/docker/containerd/specs"
 	"github.com/docker/containerd/supervisor"
 	"golang.org/x/net/context"
 )
@@ -66,7 +67,7 @@ func (s *apiServer) Signal(ctx context.Context, r *types.SignalRequest) (*types.
 }
 
 func (s *apiServer) AddProcess(ctx context.Context, r *types.AddProcessRequest) (*types.AddProcessResponse, error) {
-	process := &runtime.ProcessSpec{
+	process := &specs.ProcessSpec{
 		Terminal: r.Terminal,
 		Args:     r.Args,
 		Env:      r.Env,

--- a/api/grpc/server/server_linux.go
+++ b/api/grpc/server/server_linux.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/containerd/runtime"
+	"github.com/docker/containerd/specs"
 	"github.com/docker/containerd/supervisor"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/system"
-	"github.com/opencontainers/specs"
+	ocs "github.com/opencontainers/specs"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -241,7 +242,7 @@ func (s *apiServer) Stats(ctx context.Context, r *types.StatsRequest) (*types.St
 	return t, nil
 }
 
-func setUserFieldsInProcess(p *types.Process, oldProc runtime.ProcessSpec) {
+func setUserFieldsInProcess(p *types.Process, oldProc specs.ProcessSpec) {
 	p.User = &types.User{
 		Uid:            oldProc.User.UID,
 		Gid:            oldProc.User.GID,
@@ -249,8 +250,8 @@ func setUserFieldsInProcess(p *types.Process, oldProc runtime.ProcessSpec) {
 	}
 }
 
-func setPlatformRuntimeProcessSpecUserFields(r *types.User, process *runtime.ProcessSpec) {
-	process.User = specs.User{
+func setPlatformRuntimeProcessSpecUserFields(r *types.User, process *specs.ProcessSpec) {
+	process.User = ocs.User{
 		UID:            r.Uid,
 		GID:            r.Gid,
 		AdditionalGids: r.AdditionalGids,

--- a/api/grpc/server/server_windows.go
+++ b/api/grpc/server/server_windows.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/docker/containerd/api/grpc/types"
-	"github.com/docker/containerd/runtime"
+	"github.com/docker/containerd/specs"
 	"github.com/docker/containerd/supervisor"
 	"golang.org/x/net/context"
 )
@@ -32,8 +32,8 @@ func (s *apiServer) Stats(ctx context.Context, r *types.StatsRequest) (*types.St
 	return nil, errors.New("Stats() not supported on Windows")
 }
 
-func setUserFieldsInProcess(p *types.Process, oldProc runtime.ProcessSpec) {
+func setUserFieldsInProcess(p *types.Process, oldProc specs.ProcessSpec) {
 }
 
-func setPlatformRuntimeProcessSpecUserFields(r *types.User, process *runtime.ProcessSpec) {
+func setPlatformRuntimeProcessSpecUserFields(r *types.User, process *specs.ProcessSpec) {
 }

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/containerd/api/grpc/types"
+	"github.com/docker/containerd/specs"
 	"github.com/docker/docker/pkg/term"
-	"github.com/opencontainers/specs"
 	netcontext "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
@@ -537,24 +537,4 @@ type stdio struct {
 	stdin  string
 	stdout string
 	stderr string
-}
-
-func createStdio() (s stdio, err error) {
-	tmp, err := ioutil.TempDir("", "ctr-")
-	if err != nil {
-		return s, err
-	}
-	// create fifo's for the process
-	for name, fd := range map[string]*string{
-		"stdin":  &s.stdin,
-		"stdout": &s.stdout,
-		"stderr": &s.stderr,
-	} {
-		path := filepath.Join(tmp, name)
-		if err := syscall.Mkfifo(path, 0755); err != nil && !os.IsExist(err) {
-			return s, err
-		}
-		*fd = path
-	}
-	return s, nil
 }

--- a/ctr/container_unix.go
+++ b/ctr/container_unix.go
@@ -1,0 +1,30 @@
+// +build !windows
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func createStdio() (s stdio, err error) {
+	tmp, err := ioutil.TempDir("", "ctr-")
+	if err != nil {
+		return s, err
+	}
+	// create fifo's for the process
+	for name, fd := range map[string]*string{
+		"stdin":  &s.stdin,
+		"stdout": &s.stdout,
+		"stderr": &s.stderr,
+	} {
+		path := filepath.Join(tmp, name)
+		if err := syscall.Mkfifo(path, 0755); err != nil && !os.IsExist(err) {
+			return s, err
+		}
+		*fd = path
+	}
+	return s, nil
+}

--- a/ctr/container_windows.go
+++ b/ctr/container_windows.go
@@ -1,0 +1,6 @@
+package main
+
+// TODO Windows: This will have a very different implementation
+func createStdio() (s stdio, err error) {
+	return stdio{}, nil
+}

--- a/runtime/container_windows.go
+++ b/runtime/container_windows.go
@@ -1,9 +1,18 @@
 package runtime
 
-import "errors"
+import (
+	"errors"
 
-func getRootIDs(s *PlatformSpec) (int, int, error) {
+	"github.com/docker/containerd/specs"
+)
+
+func getRootIDs(s *specs.PlatformSpec) (int, int, error) {
 	return 0, 0, nil
+}
+
+// TODO Windows: This will have a different implementation
+func (c *container) State() State {
+	return Running // HACK HACK HACK
 }
 
 func (c *container) Runtime() string {
@@ -38,7 +47,7 @@ func (c *container) Start(checkpoint string, s Stdio) (Process, error) {
 
 // TODO Windows: Implement me.
 // This will have a very different implementation on Windows.
-func (c *container) Exec(pid string, spec ProcessSpec, s Stdio) (Process, error) {
+func (c *container) Exec(pid string, spec specs.ProcessSpec, s Stdio) (Process, error) {
 	return nil, errors.New("Exec not yet implemented on Windows")
 }
 

--- a/runtime/process.go
+++ b/runtime/process.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/docker/containerd/specs"
 )
 
 type Process interface {
@@ -25,7 +27,7 @@ type Process interface {
 	// has not exited
 	ExitStatus() (int, error)
 	// Spec returns the process spec that created the process
-	Spec() ProcessSpec
+	Spec() specs.ProcessSpec
 	// Signal sends the provided signal to the process
 	Signal(os.Signal) error
 	// Container returns the container that the process belongs to
@@ -39,8 +41,8 @@ type Process interface {
 type processConfig struct {
 	id          string
 	root        string
-	processSpec ProcessSpec
-	spec        *PlatformSpec
+	processSpec specs.ProcessSpec
+	spec        *specs.PlatformSpec
 	c           *container
 	stdio       Stdio
 	exec        bool
@@ -118,7 +120,7 @@ type process struct {
 	exitPipe    *os.File
 	controlPipe *os.File
 	container   *container
-	spec        ProcessSpec
+	spec        specs.ProcessSpec
 	stdio       Stdio
 }
 
@@ -163,7 +165,7 @@ func (p *process) ExitStatus() (int, error) {
 	return strconv.Atoi(string(data))
 }
 
-func (p *process) Spec() ProcessSpec {
+func (p *process) Spec() specs.ProcessSpec {
 	return p.spec
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"errors"
 	"time"
+
+	"github.com/docker/containerd/specs"
 )
 
 var (
@@ -46,7 +48,7 @@ type state struct {
 }
 
 type ProcessState struct {
-	ProcessSpec
+	specs.ProcessSpec
 	Exec   bool   `json:"exec"`
 	Stdin  string `json:"containerdStdin"`
 	Stdout string `json:"containerdStdout"`

--- a/runtime/spec_linux.go
+++ b/runtime/spec_linux.go
@@ -1,8 +1,0 @@
-package runtime
-
-import "github.com/opencontainers/specs"
-
-type (
-	PlatformSpec specs.LinuxSpec
-	ProcessSpec  specs.Process
-)

--- a/runtime/spec_windows.go
+++ b/runtime/spec_windows.go
@@ -1,8 +1,0 @@
-package runtime
-
-// Temporary Windows version of the spec in lieu of opencontainers/specs having
-// Windows support currently.
-import "github.com/docker/containerd/specs"
-
-type PlatformSpec specs.WindowsSpec
-type ProcessSpec specs.Process

--- a/specs/spec_linux.go
+++ b/specs/spec_linux.go
@@ -1,0 +1,9 @@
+package specs
+
+import ocs "github.com/opencontainers/specs"
+
+type (
+	PlatformSpec ocs.LinuxSpec
+	ProcessSpec  ocs.Process
+	Spec         ocs.Spec
+)

--- a/specs/spec_windows.go
+++ b/specs/spec_windows.go
@@ -1,5 +1,13 @@
 package specs
 
+// Temporary Windows version of the spec in lieu of opencontainers/specs having
+// Windows support currently.
+
+type (
+	PlatformSpec WindowsSpec
+	ProcessSpec  Process
+)
+
 // This is a temporary module in lieu of opencontainers/specs being compatible
 // currently on Windows.
 

--- a/specs/unsupported.go
+++ b/specs/unsupported.go
@@ -1,3 +1,0 @@
-// +build !windows
-
-package specs

--- a/supervisor/add_process.go
+++ b/supervisor/add_process.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/docker/containerd/runtime"
+	"github.com/docker/containerd/specs"
 )
 
 type AddProcessTask struct {
@@ -13,7 +14,7 @@ type AddProcessTask struct {
 	Stdout        string
 	Stderr        string
 	Stdin         string
-	ProcessSpec   *runtime.ProcessSpec
+	ProcessSpec   *specs.ProcessSpec
 	StartResponse chan StartResponse
 }
 

--- a/supervisor/sort_test.go
+++ b/supervisor/sort_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/docker/containerd/runtime"
+	"github.com/docker/containerd/specs"
 )
 
 type testProcess struct {
@@ -44,8 +45,8 @@ func (p *testProcess) Container() runtime.Container {
 	return nil
 }
 
-func (p *testProcess) Spec() runtime.ProcessSpec {
-	return runtime.ProcessSpec{}
+func (p *testProcess) Spec() specs.ProcessSpec {
+	return specs.ProcessSpec{}
 }
 
 func (p *testProcess) Signal(os.Signal) error {


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@mlaventure @crosbymichael. One step closer to getting ctr compiling on Windows. As spec is shared between daemon and client, moved spec 'hack' from runtime to specs package itself in the process, which also makes it a lot clearer IMO.

Have verified make all/make dtest locally on Linux.