### PR TITLE
Wait for stdio to close before exiting

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -117,6 +117,7 @@ func main() {
 		}
 		// runtime has exited so the shim can also exit
 		if exitShim {
+			p.Wait()
 			return
 		}
 	}


### PR DESCRIPTION
Does not let the shim exit if there is data that has not been written to the fifo.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>