### PR TITLE
Retry on pidfile read error

### DIFF
--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -313,7 +313,7 @@ func (c *container) writeEventFD(root string, cfd, efd int) error {
 func waitForStart(p *process, cmd *exec.Cmd) error {
 	for i := 0; i < 300; i++ {
 		if _, err := p.getPidFromFile(); err != nil {
-			if os.IsNotExist(err) {
+			if os.IsNotExist(err) || err == errInvalidPidInt {
 				alive, err := isAlive(cmd)
 				if err != nil {
 					return err

--- a/runtime/process.go
+++ b/runtime/process.go
@@ -199,7 +199,7 @@ func (p *process) getPidFromFile() (int, error) {
 	}
 	i, err := strconv.Atoi(string(data))
 	if err != nil {
-		return -1, err
+		return -1, errInvalidPidInt
 	}
 	p.pid = i
 	return i, nil

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -19,6 +19,7 @@ var (
 	ErrContainerNotStarted   = errors.New("containerd: container not started")
 
 	errNoPidFile      = errors.New("containerd: no process pid file found")
+	errInvalidPidInt  = errors.New("containerd: process pid is invalid")
 	errNotImplemented = errors.New("containerd: not implemented")
 )
 


### PR DESCRIPTION
This can be removed after runc writes pidfile atomically.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>