### PR TITLE
Fix Git commit not show in Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BUILDTAGS=
 
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || true)
 
-LDFLAGS := "-X github.com/docker/containerd.GitCommit=${GIT_COMMIT} ${LDFLAGS}"
+LDFLAGS := "${LDFLAGS} -X github.com/docker/containerd.GitCommit=${GIT_COMMIT}"
 
 # if this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach


### PR DESCRIPTION
If ${LDFLAGS} is empty, `containerd -v` can't show git commit number,
which is very depressing.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>