### PR TITLE
Dockerfile: use Go 1.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install Go
-ENV GO_VERSION 1.5.2
+ENV GO_VERSION 1.5.3
 RUN curl -sSL  "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar -v -C /usr/local -xz
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/containerd/vendor


### PR DESCRIPTION
Go 1.5.2 is known to have security vulnerabilities in the standard
library. As such, we should use 1.5.3.

Signed-off-by: Aleksa Sarai <asarai@suse.de>