### PR TITLE
Retrieve ctr missed events once connection is re-established

### DIFF
--- a/ctr/container.go
+++ b/ctr/container.go
@@ -568,13 +568,15 @@ var updateCommand = cli.Command{
 }
 
 func waitForExit(c types.APIClient, events types.API_EventsClient, id, pid string, closer func()) {
+	timestamp := uint64(time.Now().Unix())
 	for {
 		e, err := events.Recv()
 		if err != nil {
 			time.Sleep(1 * time.Second)
-			events, _ = c.Events(netcontext.Background(), &types.EventsRequest{})
+			events, _ = c.Events(netcontext.Background(), &types.EventsRequest{Timestamp: timestamp})
 			continue
 		}
+		timestamp = e.Timestamp
 		if e.Id == id && e.Type == "exit" && e.Pid == pid {
 			closer()
 			os.Exit(int(e.Status))


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

---

This still leave ctr hanging around if it's attach to a process that exits while `containerd` is dead if `containerd` is never restarted.

I guess we could detect this since the `io.Copy` for `stdout` and `stderr` should have been closed (but that'd require us not to open them with `O_RDWR` from `ctr`)
