### PR TITLE
Fix closing stdin before everything has been written to pipe

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -89,7 +89,9 @@ func start() error {
 			switch msg {
 			case 0:
 				// close stdin
-				p.shimIO.Stdin.Close()
+				if p.stdinCloser != nil {
+					p.stdinCloser.Close()
+				}
 			case 1:
 				if p.console == nil {
 					continue


### PR DESCRIPTION
This should fix the https://github.com/docker/docker/issues/21439

I also tried closing the `RDWR` fifo but it didn't seem to have any effect on a blocked read. I doubt select/epoll would also work on this fifo. Opening fifo 2 times from either side was the best solution I found.

@crosbymichael @mlaventure

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>