### PR TITLE
Add runtimeArgs to pass to shim

### DIFF
--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -91,10 +91,10 @@ func (p *process) start() error {
 		return err
 	}
 	logPath := filepath.Join(cwd, "log.json")
-	args := []string{
+	args := append([]string{
 		"--log", logPath,
 		"--log-format", "json",
-	}
+	}, p.state.RuntimeArgs...)
 	if p.state.Exec {
 		args = append(args, "exec",
 			"--process", filepath.Join(cwd, "process.json"),

--- a/containerd/main.go
+++ b/containerd/main.go
@@ -50,6 +50,11 @@ var daemonFlags = []cli.Flag{
 		Value: "runc",
 		Usage: "name of the OCI compliant runtime to use when executing containers",
 	},
+	cli.StringSliceFlag{
+		Name:  "runtime-args",
+		Value: &cli.StringSlice{},
+		Usage: "specify additional runtime args",
+	},
 }
 
 func main() {
@@ -71,6 +76,7 @@ func main() {
 			context.String("state-dir"),
 			10,
 			context.String("runtime"),
+			context.StringSlice("runtime-args"),
 		); err != nil {
 			logrus.Fatal(err)
 		}
@@ -80,7 +86,7 @@ func main() {
 	}
 }
 
-func daemon(address, stateDir string, concurrency int, runtimeName string) error {
+func daemon(address, stateDir string, concurrency int, runtimeName string, runtimeArgs []string) error {
 	// setup a standard reaper so that we don't leave any zombies if we are still alive
 	// this is just good practice because we are spawning new processes
 	s := make(chan os.Signal, 2048)
@@ -88,7 +94,7 @@ func daemon(address, stateDir string, concurrency int, runtimeName string) error
 	if err := osutils.SetSubreaper(1); err != nil {
 		logrus.WithField("error", err).Error("containerd: set subpreaper")
 	}
-	sv, err := supervisor.New(stateDir, runtimeName)
+	sv, err := supervisor.New(stateDir, runtimeName, runtimeArgs)
 	if err != nil {
 		return err
 	}

--- a/runtime/process_linux.go
+++ b/runtime/process_linux.go
@@ -35,8 +35,9 @@ func populateProcessStateForEncoding(config *processConfig, uid int, gid int) Pr
 			RootUID:    uid,
 			RootGID:    gid,
 		},
-		Stdin:  config.stdio.Stdin,
-		Stdout: config.stdio.Stdout,
-		Stderr: config.stdio.Stderr,
+		Stdin:       config.stdio.Stdin,
+		Stdout:      config.stdio.Stdout,
+		Stderr:      config.stdio.Stderr,
+		RuntimeArgs: config.c.runtimeArgs,
 	}
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -53,20 +53,22 @@ const (
 )
 
 type state struct {
-	Bundle  string   `json:"bundle"`
-	Labels  []string `json:"labels"`
-	Stdin   string   `json:"stdin"`
-	Stdout  string   `json:"stdout"`
-	Stderr  string   `json:"stderr"`
-	Runtime string   `json:"runtime"`
+	Bundle      string   `json:"bundle"`
+	Labels      []string `json:"labels"`
+	Stdin       string   `json:"stdin"`
+	Stdout      string   `json:"stdout"`
+	Stderr      string   `json:"stderr"`
+	Runtime     string   `json:"runtime"`
+	RuntimeArgs []string `json:"runtimeArgs"`
 }
 
 type ProcessState struct {
 	specs.ProcessSpec
-	Exec   bool   `json:"exec"`
-	Stdin  string `json:"containerdStdin"`
-	Stdout string `json:"containerdStdout"`
-	Stderr string `json:"containerdStderr"`
+	Exec        bool     `json:"exec"`
+	Stdin       string   `json:"containerdStdin"`
+	Stdout      string   `json:"containerdStdout"`
+	Stderr      string   `json:"containerdStderr"`
+	RuntimeArgs []string `json:"runtimeArgs"`
 
 	PlatformProcessState
 }

--- a/supervisor/create.go
+++ b/supervisor/create.go
@@ -20,7 +20,7 @@ type StartTask struct {
 
 func (s *Supervisor) start(t *StartTask) error {
 	start := time.Now()
-	container, err := runtime.New(s.stateDir, t.ID, t.BundlePath, s.runtime, t.Labels)
+	container, err := runtime.New(s.stateDir, t.ID, t.BundlePath, s.runtime, s.runtimeArgs, t.Labels)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows you to pass options like:

```bash
containerd --debug --runtime-args "--debug" --runtime-args
"--systemd-cgroup"
```

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>