### PR TITLE
Ensure that --root is passed to oci when using runtime args

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -206,7 +206,11 @@ func (c *container) readSpec() (*specs.Spec, error) {
 
 func (c *container) Delete() error {
 	err := os.RemoveAll(filepath.Join(c.root, c.id))
-	exec.Command(c.runtime, "delete", c.id).Run()
+
+	args := c.runtimeArgs
+	args = append(args, "delete", c.id)
+	exec.Command(c.runtime, args...).Run()
+
 	return err
 }
 

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -51,11 +51,15 @@ func (c *container) Runtime() string {
 }
 
 func (c *container) Pause() error {
-	return exec.Command(c.runtime, "pause", c.id).Run()
+	args := c.runtimeArgs
+	args = append(args, "pause", c.id)
+	return exec.Command(c.runtime, args...).Run()
 }
 
 func (c *container) Resume() error {
-	return exec.Command(c.runtime, "resume", c.id).Run()
+	args := c.runtimeArgs
+	args = append(args, "resume", c.id)
+	return exec.Command(c.runtime, args...).Run()
 }
 
 func (c *container) Checkpoints() ([]Checkpoint, error) {
@@ -107,6 +111,7 @@ func (c *container) Checkpoint(cpt Checkpoint) error {
 	add := func(flags ...string) {
 		args = append(args, flags...)
 	}
+	add(c.runtimeArgs...)
 	if !cpt.Exit {
 		add("--leave-running")
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>