### PR TITLE
Remove dep on larger packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ daemon-static:
 	cd containerd && go build -ldflags "-w -extldflags -static ${LDFLAGS}" -tags "$(BUILDTAGS)" -o ../bin/containerd
 
 shim: bin
-	cd containerd-shim && go build -tags "$(BUILDTAGS)" -o ../bin/containerd-shim
+	cd containerd-shim && go build -tags "$(BUILDTAGS)" -ldflags "-w" -o ../bin/containerd-shim
 
 shim-static:
 	cd containerd-shim && go build -ldflags "-w -extldflags -static ${LDFLAGS}" -tags "$(BUILDTAGS)" -o ../bin/containerd-shim

--- a/containerd-shim/console.go
+++ b/containerd-shim/console.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// NewConsole returns an initalized console that can be used within a container by copying bytes
+// from the master side to the slave that is attached as the tty for the container's init process.
+func newConsole(uid, gid int) (*os.File, string, error) {
+	master, err := os.OpenFile("/dev/ptmx", syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, "", err
+	}
+	console, err := ptsname(master)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := unlockpt(master); err != nil {
+		return nil, "", err
+	}
+	if err := os.Chmod(console, 0600); err != nil {
+		return nil, "", err
+	}
+	if err := os.Chown(console, uid, gid); err != nil {
+		return nil, "", err
+	}
+	return master, console, nil
+}
+
+func ioctl(fd uintptr, flag, data uintptr) error {
+	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, flag, data); err != 0 {
+		return err
+	}
+	return nil
+}
+
+// unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
+// unlockpt should be called before opening the slave side of a pty.
+func unlockpt(f *os.File) error {
+	var u int32
+	return ioctl(f.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+}
+
+// ptsname retrieves the name of the first available pts for the given master.
+func ptsname(f *os.File) (string, error) {
+	var n int32
+	if err := ioctl(f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}

--- a/osutils/reaper.go
+++ b/osutils/reaper.go
@@ -2,11 +2,7 @@
 
 package osutils
 
-import (
-	"syscall"
-
-	"github.com/opencontainers/runc/libcontainer/utils"
-)
+import "syscall"
 
 // Exit is the wait4 information from an exited process
 type Exit struct {
@@ -34,7 +30,18 @@ func Reap() (exits []Exit, err error) {
 		}
 		exits = append(exits, Exit{
 			Pid:    pid,
-			Status: utils.ExitStatus(ws),
+			Status: exitStatus(ws),
 		})
 	}
+}
+
+const exitSignalOffset = 128
+
+// exitStatus returns the correct exit status for a process based on if it
+// was signaled or exited cleanly
+func exitStatus(status syscall.WaitStatus) int {
+	if status.Signaled() {
+		return exitSignalOffset + int(status.Signal())
+	}
+	return status.ExitStatus()
 }


### PR DESCRIPTION
This removes most of the deps on the larger packages for the shim and
reduces the binary size and memory footprint from a 7.1mb binary to a
3.4mb binary.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>