### PR TITLE
Error oom if container has not stopped

### DIFF
--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -53,7 +53,9 @@ func (w *worker) Start() {
 			continue
 		}
 		if err := w.s.monitor.MonitorOOM(t.Container); err != nil && err != runtime.ErrContainerExited {
-			logrus.WithField("error", err).Error("containerd: notify OOM events")
+			if process.State() != runtime.Stopped {
+				logrus.WithField("error", err).Error("containerd: notify OOM events")
+			}
 		}
 		if err := w.s.monitorProcess(process); err != nil {
 			logrus.WithField("error", err).Error("containerd: add process to monitor")


### PR DESCRIPTION
The oom control file may not exist if the container is short lived and
exits before we can open it.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>