### PR TITLE
Provide more useful help information for ctr

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The included `ctr` command-line tool allows you interact with the containerd dae
 $ sudo ctr containers start redis /containers/redis
 $ sudo ctr containers list
 ID                  PATH                STATUS              PROCESSES
-1                   /containers/redis   running             14063
+redis               /containers/redis   running             14063
 ```
 
 `/containers/redis` is the path to an OCI bundle. [See the docs for more information.](docs/bundle.md)

--- a/ctr/checkpoint.go
+++ b/ctr/checkpoint.go
@@ -10,14 +10,24 @@ import (
 	netcontext "golang.org/x/net/context"
 )
 
+var checkpointSubCmds = []cli.Command{
+	listCheckpointCommand,
+	createCheckpointCommand,
+	deleteCheckpointCommand,
+}
+
 var checkpointCommand = cli.Command{
-	Name:  "checkpoints",
-	Usage: "list all checkpoints",
-	Subcommands: []cli.Command{
-		listCheckpointCommand,
-		createCheckpointCommand,
-		deleteCheckpointCommand,
-	},
+	Name:        "checkpoints",
+	Usage:       "list all checkpoints",
+	ArgsUsage:   "COMMAND [arguments...]",
+	Subcommands: checkpointSubCmds,
+	Description: func() string {
+		desc := "\n    COMMAND:\n"
+		for _, command := range checkpointSubCmds {
+			desc += fmt.Sprintf("    %-10.10s%s\n", command.Name, command.Usage)
+		}
+		return desc
+	}(),
 	Action: listCheckpoints,
 }
 

--- a/ctr/container.go
+++ b/ctr/container.go
@@ -41,20 +41,30 @@ func getClient(ctx *cli.Context) types.APIClient {
 	return types.NewAPIClient(conn)
 }
 
+var contSubCmds = []cli.Command{
+	execCommand,
+	killCommand,
+	listCommand,
+	pauseCommand,
+	resumeCommand,
+	startCommand,
+	statsCommand,
+	watchCommand,
+	updateCommand,
+}
+
 var containersCommand = cli.Command{
-	Name:  "containers",
-	Usage: "interact with running containers",
-	Subcommands: []cli.Command{
-		execCommand,
-		killCommand,
-		listCommand,
-		pauseCommand,
-		resumeCommand,
-		startCommand,
-		statsCommand,
-		watchCommand,
-		updateCommand,
-	},
+	Name:        "containers",
+	Usage:       "interact with running containers",
+	ArgsUsage:   "COMMAND [arguments...]",
+	Subcommands: contSubCmds,
+	Description: func() string {
+		desc := "\n    COMMAND:\n"
+		for _, command := range contSubCmds {
+			desc += fmt.Sprintf("    %-10.10s%s\n", command.Name, command.Usage)
+		}
+		return desc
+	}(),
 	Action: listContainers,
 }
 
@@ -107,8 +117,9 @@ func listContainers(context *cli.Context) {
 }
 
 var startCommand = cli.Command{
-	Name:  "start",
-	Usage: "start a container",
+	Name:      "start",
+	Usage:     "start a container",
+	ArgsUsage: "ID BundlePath",
 	Flags: []cli.Flag{
 		cli.StringFlag{
 			Name:  "checkpoint,c",


### PR DESCRIPTION
`ctr containers/checkpoints` contains lots of important subcommands,
but now help command can't show subcommands. Adding subcommands to
help information will avoid user from digging into the code for
getting necessary command list.


Signed-off-by: Zhang Wei <zhangwei555@huawei.com>