### PR TITLE
Move event types constants into single file

### DIFF
--- a/supervisor/add_process.go
+++ b/supervisor/add_process.go
@@ -35,7 +35,7 @@ func (s *Supervisor) addProcess(t *AddProcessTask) error {
 	t.StartResponse <- StartResponse{}
 	s.notifySubscribers(Event{
 		Timestamp: time.Now(),
-		Type:      "start-process",
+		Type:      StateStartProcess,
 		PID:       t.PID,
 		ID:        t.ID,
 	})

--- a/supervisor/delete.go
+++ b/supervisor/delete.go
@@ -23,7 +23,7 @@ func (s *Supervisor) delete(t *DeleteTask) error {
 		}
 		if !t.NoEvent {
 			s.notifySubscribers(Event{
-				Type:      "exit",
+				Type:      StateExit,
 				Timestamp: time.Now(),
 				ID:        t.ID,
 				Status:    t.Status,

--- a/supervisor/exit.go
+++ b/supervisor/exit.go
@@ -73,7 +73,7 @@ func (s *Supervisor) execExit(t *ExecExitTask) error {
 	s.notifySubscribers(Event{
 		Timestamp: time.Now(),
 		ID:        t.ID,
-		Type:      "exit",
+		Type:      StateExit,
 		PID:       t.PID,
 		Status:    t.Status,
 	})

--- a/supervisor/oom.go
+++ b/supervisor/oom.go
@@ -16,7 +16,7 @@ func (s *Supervisor) oom(t *OOMTask) error {
 	s.notifySubscribers(Event{
 		Timestamp: time.Now(),
 		ID:        t.ID,
-		Type:      "oom",
+		Type:      StateOOM,
 	})
 	return nil
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -161,7 +161,7 @@ func (s *Supervisor) Events(from time.Time) chan Event {
 		}
 		// Notify the client that from now on it's live events
 		c <- Event{
-			Type:      "live",
+			Type:      StateLive,
 			Timestamp: time.Now(),
 		}
 	}

--- a/supervisor/types.go
+++ b/supervisor/types.go
@@ -1,0 +1,12 @@
+package supervisor
+
+// State constants used in Event types
+const (
+	StateStart        = "start-container"
+	StatePause        = "pause"
+	StateResume       = "resume"
+	StateExit         = "exit"
+	StateStartProcess = "start-process"
+	StateOOM          = "oom"
+	StateLive         = "live"
+)

--- a/supervisor/update.go
+++ b/supervisor/update.go
@@ -27,7 +27,7 @@ func (s *Supervisor) updateContainer(t *UpdateTask) error {
 			}
 			s.notifySubscribers(Event{
 				ID:        t.ID,
-				Type:      "resume",
+				Type:      StateResume,
 				Timestamp: time.Now(),
 			})
 		case runtime.Paused:
@@ -36,7 +36,7 @@ func (s *Supervisor) updateContainer(t *UpdateTask) error {
 			}
 			s.notifySubscribers(Event{
 				ID:        t.ID,
-				Type:      "pause",
+				Type:      StatePause,
 				Timestamp: time.Now(),
 			})
 		default:

--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -68,7 +68,7 @@ func (w *worker) Start() {
 		w.s.notifySubscribers(Event{
 			Timestamp: time.Now(),
 			ID:        t.Container.ID(),
-			Type:      "start-container",
+			Type:      StateStart,
 		})
 	}
 }


### PR DESCRIPTION
Move all constants for event types to types.go for easier code
readability and maintainance.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>