### PR TITLE
Bugfix: ctr container list can not get the proper status of container

### DIFF
--- a/api/grpc/server/server.go
+++ b/api/grpc/server/server.go
@@ -146,7 +146,11 @@ func createAPIContainer(c runtime.Container, getPids bool) (*types.Container, er
 		procs = append(procs, appendToProcs)
 	}
 	var pids []int
-	state := c.State()
+	state, err := c.Status()
+	if err != nil {
+		return nil, grpc.Errorf(codes.Internal, "get status for container: "+err.Error())
+	}
+
 	if getPids && (state == runtime.Running || state == runtime.Paused) {
 		if pids, err = c.Pids(); err != nil {
 			return nil, grpc.Errorf(codes.Internal, "get all pids for container: "+err.Error())

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -52,6 +52,9 @@ type Container interface {
 	OOM() (OOM, error)
 	// UpdateResource updates the containers resources to new values
 	UpdateResources(*Resource) error
+
+	// Status return the current status of the container.
+	Status() (State, error)
 }
 
 type OOM interface {

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -284,6 +284,11 @@ func (c *container) Stats() (*Stat, error) {
 	}, nil
 }
 
+// Status implements the runtime Container interface.
+func (c *container) Status() (State, error) {
+	return "running", nil
+}
+
 func (c *container) OOM() (OOM, error) {
 	container, err := c.getLibctContainer()
 	if err != nil {

--- a/runtime/container_windows.go
+++ b/runtime/container_windows.go
@@ -61,6 +61,11 @@ func (c *container) Stats() (*Stat, error) {
 	return nil, errors.New("Stats not yet implemented on Windows")
 }
 
+// Status implements the runtime Container interface.
+func (c *container) Status() (State, error) {
+	return "", errors.New("Status not yet implemented on Windows")
+}
+
 func (c *container) OOM() (OOM, error) {
 	return nil, errors.New("OOM not yet implemented on Windows")
 }

--- a/supervisor/get_containers.go
+++ b/supervisor/get_containers.go
@@ -9,16 +9,20 @@ type GetContainersTask struct {
 }
 
 func (s *Supervisor) getContainers(t *GetContainersTask) error {
+
 	if t.ID != "" {
-		ci := s.containers[t.ID]
-		if ci == nil {
+		ci, ok := s.containers[t.ID]
+		if !ok {
 			return ErrContainerNotFound
 		}
 		t.Containers = append(t.Containers, ci.container)
+
 		return nil
 	}
-	for _, i := range s.containers {
-		t.Containers = append(t.Containers, i.container)
+
+	for _, ci := range s.containers {
+		t.Containers = append(t.Containers, ci.container)
 	}
+
 	return nil
 }


### PR DESCRIPTION
 Prior to this patch, when list containers by "ctr containers" or
"ctr containers xxx", it will not get the proper status of conatinser(s).

for example:
```
h00283522@ubuntu:~$ sudo ctr containers
ID                  PATH                                  STATUS              PROCESSES
hukeping_xxx        /home/h00283522/test_for_containerd   running             init
hukeping_yyy        /home/h00283522/test_for_containerd   running             init
h00283522@ubuntu:~$ sudo ctr containers pause hukeping_xxx
h00283522@ubuntu:~$ 
h00283522@ubuntu:~$ 
h00283522@ubuntu:~$ sudo ctr containers
ID                  PATH                                  STATUS              PROCESSES
hukeping_xxx        /home/h00283522/test_for_containerd   running             init
hukeping_yyy        /home/h00283522/test_for_containerd   running             init
```

That was caused by the wrong implementation of State() for structure process,
it only send a signal "0" to ping the "init" process and do nothing.
    
Since the OCI/runc has implemented an interface Status(), we can use that.
And I think this is more compatible with the design for containerd:
- containerd -> runtime -> fun()


This patch set first introduced an interface to runtime container and then
reworked the `ctr containers list `