### PR TITLE
Correct build flag for arm64

### DIFF
--- a/archutils/epoll.go
+++ b/archutils/epoll.go
@@ -1,4 +1,4 @@
-// +build linux,!aarch64
+// +build linux,!arm64
 
 package archutils
 

--- a/archutils/epoll_arm64.go
+++ b/archutils/epoll_arm64.go
@@ -1,4 +1,4 @@
-// +build linux,aarch64
+// +build linux,arm64
 
 package archutils
 


### PR DESCRIPTION
On arm64, the default build flag is the same as the one from
`go env` which is arm64. So we should use arm64 instead of
aarch64 for both build flag and file name.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>