### PR TITLE
Sometimes you feel like a shim, sometimes you don't

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,8 @@ test: validate install bundles-rootfs
 	go test -bench=. -v $(shell go list ./... | grep -v /vendor | grep -v /integration-test)
 ifneq ($(wildcard /.dockerenv), )
 	cd integration-test ; \
-	go test -check.v -check.timeout=$(TEST_TIMEOUT) timeout=$(TEST_SUITE_TIMEOUT) $(TESTFLAGS) github.com/docker/containerd/integration-test
+	go test -check.v -check.timeout=$(TEST_TIMEOUT) -timeout=$(TEST_SUITE_TIMEOUT) $(TESTFLAGS) github.com/docker/containerd/integration-test && \
+	go test -containerd.shim="" -check.v -check.timeout=$(TEST_TIMEOUT) -timeout=$(TEST_SUITE_TIMEOUT) $(TESTFLAGS) github.com/docker/containerd/integration-test
 endif
 
 bench: shim validate install bundles-rootfs

--- a/containerd/main.go
+++ b/containerd/main.go
@@ -131,7 +131,10 @@ func daemon(context *cli.Context) error {
 	// setup a standard reaper so that we don't leave any zombies if we are still alive
 	// this is just good practice because we are spawning new processes
 	s := make(chan os.Signal, 2048)
-	signal.Notify(s, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(s, syscall.SIGCHLD, syscall.SIGTERM, syscall.SIGINT)
+	if err := osutils.SetSubreaper(1); err != nil {
+		logrus.WithField("error", err).Error("containerd: set subpreaper")
+	}
 	sv, err := supervisor.New(
 		context.String("state-dir"),
 		context.String("runtime"),
@@ -163,6 +166,10 @@ func daemon(context *cli.Context) error {
 	}
 	for ss := range s {
 		switch ss {
+		case syscall.SIGCHLD:
+			if _, err := osutils.Reap(); err != nil {
+				logrus.WithField("error", err).Warn("containerd: reap child processes")
+			}
 		default:
 			logrus.Infof("stopping containerd after receiving %s", ss)
 			server.Stop()

--- a/integration-test/check_test.go
+++ b/integration-test/check_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -21,6 +22,10 @@ import (
 	"github.com/docker/containerd/api/grpc/types"
 	utils "github.com/docker/containerd/testutils"
 	"github.com/go-check/check"
+)
+
+var (
+	ShimFlag = flag.String("containerd.shim", "containerd-shim", "containerd shim to use")
 )
 
 func Test(t *testing.T) {
@@ -131,6 +136,7 @@ func (cs *ContainerdSuite) RestartDaemon(kill bool) error {
 	cs.StopDaemon(kill)
 
 	cd := exec.Command("containerd", "--debug",
+		"--shim", *ShimFlag,
 		"--state-dir", cs.stateDir,
 		"--listen", cs.grpcSocket,
 		"--metrics-interval", "0m0s",

--- a/integration-test/start_test.go
+++ b/integration-test/start_test.go
@@ -315,6 +315,10 @@ func (cs *ContainerdSuite) TestStartBusyboxTopPauseResume(t *check.C) {
 }
 
 func (cs *ContainerdSuite) TestRestart(t *check.C) {
+	if *ShimFlag == "" {
+		return
+	}
+
 	bundleName := "busybox-top"
 	if err := CreateBusyboxBundle(bundleName, []string{"top"}); err != nil {
 		t.Fatal(err)

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -394,7 +394,7 @@ func (c *container) Start(checkpointPath string, s Stdio) (Process, error) {
 		spec:        spec,
 		processSpec: specs.ProcessSpec(spec.Process),
 	}
-	p, err := newProcess(config)
+	p, err := c.newProcess(config)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (c *container) Exec(pid string, pspec specs.ProcessSpec, s Stdio) (pp Proce
 		spec:        spec,
 		stdio:       s,
 	}
-	p, err := newProcess(config)
+	p, err := c.newProcess(config)
 	if err != nil {
 		return nil, err
 	}
@@ -508,6 +508,13 @@ func (c *container) writeEventFD(root string, cfd, efd int) error {
 	defer f.Close()
 	_, err = f.WriteString(fmt.Sprintf("%d %d", efd, cfd))
 	return err
+}
+
+func (c *container) newProcess(config *processConfig) (Process, error) {
+	if c.shim == "" {
+		return newDirectProcess(config)
+	}
+	return newProcess(config)
 }
 
 type waitArgs struct {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/containerd/specs"
+	"github.com/docker/containerd/subreaper/exec"
 	ocs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -452,7 +452,6 @@ func (c *container) Exec(pid string, pspec specs.ProcessSpec, s Stdio) (pp Proce
 }
 
 func (c *container) startCmd(pid string, cmd *exec.Cmd, p *process) error {
-	p.cmd = cmd
 	if err := cmd.Start(); err != nil {
 		if exErr, ok := err.(*exec.Error); ok {
 			if exErr.Err == exec.ErrNotFound || exErr.Err == os.ErrNotExist {
@@ -613,9 +612,6 @@ func (c *container) waitForStart(p *process, cmd *exec.Cmd) error {
 
 // isAlive checks if the shim that launched the container is still alive
 func isAlive(cmd *exec.Cmd) (bool, error) {
-	if _, err := syscall.Wait4(cmd.Process.Pid, nil, syscall.WNOHANG, nil); err == nil {
-		return true, nil
-	}
 	if err := syscall.Kill(cmd.Process.Pid, 0); err != nil {
 		if err == syscall.ESRCH {
 			return false, nil

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 
 	"github.com/docker/containerd/specs"
+	"github.com/docker/containerd/subreaper/exec"
 	"github.com/opencontainers/runc/libcontainer"
 	ocs "github.com/opencontainers/runtime-spec/specs-go"
 )

--- a/runtime/direct_process.go
+++ b/runtime/direct_process.go
@@ -1,0 +1,283 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/docker/containerd/specs"
+	"github.com/docker/containerd/subreaper"
+	"github.com/docker/containerd/subreaper/exec"
+	"github.com/docker/docker/pkg/term"
+	"github.com/opencontainers/runc/libcontainer"
+)
+
+type directProcess struct {
+	*process
+	sync.WaitGroup
+
+	io          stdio
+	console     libcontainer.Console
+	consolePath string
+	exec        bool
+	checkpoint  string
+	specs       *specs.Spec
+}
+
+func newDirectProcess(config *processConfig) (*directProcess, error) {
+	lp, err := newProcess(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &directProcess{
+		specs:      config.spec,
+		process:    lp,
+		exec:       config.exec,
+		checkpoint: config.checkpoint,
+	}, nil
+}
+
+func (d *directProcess) CloseStdin() error {
+	if d.io.stdin != nil {
+		return d.io.stdin.Close()
+	}
+	return nil
+}
+
+func (d *directProcess) Resize(w, h int) error {
+	if d.console == nil {
+		return nil
+	}
+	ws := term.Winsize{
+		Width:  uint16(w),
+		Height: uint16(h),
+	}
+	return term.SetWinsize(d.console.Fd(), &ws)
+}
+
+func (d *directProcess) openIO() (*os.File, *os.File, *os.File, error) {
+	uid, gid, err := getRootIDs(d.specs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if d.spec.Terminal {
+		console, err := libcontainer.NewConsole(uid, gid)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		d.console = console
+		d.consolePath = console.Path()
+		stdin, err := os.OpenFile(d.stdio.Stdin, syscall.O_RDONLY, 0)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		go io.Copy(console, stdin)
+		stdout, err := os.OpenFile(d.stdio.Stdout, syscall.O_RDWR, 0)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		d.Add(1)
+		go func() {
+			io.Copy(stdout, console)
+			console.Close()
+			d.Done()
+		}()
+		d.io.stdin = stdin
+		d.io.stdout = stdout
+		d.io.stderr = stdout
+		return nil, nil, nil, nil
+	}
+
+	stdin, err := os.OpenFile(d.stdio.Stdin, syscall.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	stdout, err := os.OpenFile(d.stdio.Stdout, syscall.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	stderr, err := os.OpenFile(d.stdio.Stderr, syscall.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	d.io.stdin = stdin
+	d.io.stdout = stdout
+	d.io.stderr = stderr
+	return stdin, stdout, stderr, nil
+}
+
+func (d *directProcess) loadCheckpoint(bundle string) (*Checkpoint, error) {
+	if d.checkpoint == "" {
+		return nil, nil
+	}
+
+	f, err := os.Open(filepath.Join(bundle, "checkpoints", d.checkpoint, "config.json"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var cpt Checkpoint
+	if err := json.NewDecoder(f).Decode(&cpt); err != nil {
+		return nil, err
+	}
+	return &cpt, nil
+}
+
+func (d *directProcess) Start() error {
+	cwd, err := filepath.Abs(d.root)
+	if err != nil {
+		return err
+	}
+
+	stdin, stdout, stderr, err := d.openIO()
+	if err != nil {
+		return nil
+	}
+
+	checkpoint, err := d.loadCheckpoint(d.container.bundle)
+	if err != nil {
+		return err
+	}
+
+	logPath := filepath.Join(cwd, "log.json")
+	args := append([]string{
+		"--log", logPath,
+		"--log-format", "json",
+	}, d.container.runtimeArgs...)
+	if d.exec {
+		args = append(args, "exec",
+			"--process", filepath.Join(cwd, "process.json"),
+			"--console", d.consolePath,
+		)
+	} else if checkpoint != nil {
+		args = append(args, "restore",
+			"--image-path", filepath.Join(d.container.bundle, "checkpoints", checkpoint.Name),
+		)
+		add := func(flags ...string) {
+			args = append(args, flags...)
+		}
+		if checkpoint.Shell {
+			add("--shell-job")
+		}
+		if checkpoint.Tcp {
+			add("--tcp-established")
+		}
+		if checkpoint.UnixSockets {
+			add("--ext-unix-sk")
+		}
+		if d.container.noPivotRoot {
+			add("--no-pivot")
+		}
+	} else {
+		args = append(args, "start",
+			"--bundle", d.container.bundle,
+			"--console", d.consolePath,
+		)
+		if d.container.noPivotRoot {
+			args = append(args, "--no-pivot")
+		}
+	}
+	args = append(args,
+		"-d",
+		"--pid-file", filepath.Join(cwd, "pid"),
+		d.container.id,
+	)
+	cmd := exec.Command(d.container.runtime, args...)
+	cmd.Dir = d.container.bundle
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	// set the parent death signal to SIGKILL so that if containerd dies the container
+	// process also dies
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+
+	exitSubscription := subreaper.Subscribe()
+	err = d.startCmd(cmd)
+	if err != nil {
+		subreaper.Unsubscribe(exitSubscription)
+		d.delete()
+		return err
+	}
+
+	go d.watch(cmd, exitSubscription)
+
+	return nil
+}
+
+func (d *directProcess) watch(cmd *exec.Cmd, exitSubscription *subreaper.Subscription) {
+	defer subreaper.Unsubscribe(exitSubscription)
+	defer d.delete()
+
+	f, err := os.OpenFile(path.Join(d.root, ExitFile), syscall.O_WRONLY, 0)
+	if err == nil {
+		defer f.Close()
+	}
+
+	exitCode := 0
+	if err = cmd.Wait(); err != nil {
+		if exitError, ok := err.(exec.ExitCodeError); ok {
+			exitCode = exitError.Code
+		}
+	}
+
+	if exitCode == 0 {
+		pid, err := d.getPidFromFile()
+		if err != nil {
+			return
+		}
+		exitSubscription.SetPid(pid)
+		exitCode = exitSubscription.Wait()
+	}
+
+	writeInt(path.Join(d.root, ExitStatusFile), exitCode)
+}
+
+func (d *directProcess) delete() {
+	if d.console != nil {
+		d.console.Close()
+	}
+	d.io.Close()
+	d.Wait()
+	if !d.exec {
+		exec.Command(d.container.runtime, append(d.container.runtimeArgs, "delete", d.container.id)...).Run()
+	}
+}
+
+func writeInt(path string, i int) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = fmt.Fprintf(f, "%d", i)
+	return err
+}
+
+type stdio struct {
+	stdin  *os.File
+	stdout *os.File
+	stderr *os.File
+}
+
+func (s stdio) Close() error {
+	err := s.stdin.Close()
+	if oerr := s.stdout.Close(); err == nil {
+		err = oerr
+	}
+	if oerr := s.stderr.Close(); err == nil {
+		err = oerr
+	}
+	return err
+}

--- a/runtime/process.go
+++ b/runtime/process.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -41,8 +40,6 @@ type Process interface {
 	SystemPid() int
 	// State returns if the process is running or not
 	State() State
-	// Wait reaps the shim process if avaliable
-	Wait()
 }
 
 type processConfig struct {
@@ -143,7 +140,6 @@ type process struct {
 	container   *container
 	spec        specs.ProcessSpec
 	stdio       Stdio
-	cmd         *exec.Cmd
 }
 
 func (p *process) ID() string {
@@ -222,13 +218,6 @@ func (p *process) getPidFromFile() (int, error) {
 	}
 	p.pid = i
 	return i, nil
-}
-
-// Wait will reap the shim process
-func (p *process) Wait() {
-	if p.cmd != nil {
-		p.cmd.Wait()
-	}
 }
 
 func getExitPipe(path string) (*os.File, error) {

--- a/subreaper/exec/copy.go
+++ b/subreaper/exec/copy.go
@@ -1,0 +1,54 @@
+package exec
+
+import (
+	"bytes"
+	"errors"
+)
+
+// Below is largely a copy from go's os/exec/exec.go
+
+// Run starts the specified command and waits for it to complete.
+//
+// The returned error is nil if the command runs, has no problems
+// copying stdin, stdout, and stderr, and exits with a zero exit
+// status.
+//
+// If the command fails to run or doesn't complete successfully, the
+// error is of type *ExitError. Other error types may be
+// returned for I/O problems.
+func (c *Cmd) Run() error {
+	if err := c.Start(); err != nil {
+		return translateError(err)
+	}
+	return translateError(c.Wait())
+}
+
+// Output runs the command and returns its standard output.
+// Any returned error will usually be of type *ExitError.
+// If c.Stderr was nil, Output populates ExitError.Stderr.
+func (c *Cmd) Output() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	var stdout bytes.Buffer
+	c.Stdout = &stdout
+
+	err := c.Run()
+	return stdout.Bytes(), err
+}
+
+// CombinedOutput runs the command and returns its combined standard
+// output and standard error.
+func (c *Cmd) CombinedOutput() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	if c.Stderr != nil {
+		return nil, errors.New("exec: Stderr already set")
+	}
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+	err := c.Run()
+	return b.Bytes(), err
+}

--- a/subreaper/exec/wrapper.go
+++ b/subreaper/exec/wrapper.go
@@ -59,6 +59,9 @@ func (c *Cmd) Start() error {
 }
 
 func (c *Cmd) Wait() error {
+	// c.Cmd.Wait() will always error because there is no child process anymore
+	// This is called to ensure that the streams are closed and cleaned up properly
+	defer c.Cmd.Wait()
 	if c.sub == nil {
 		return c.err
 	}

--- a/subreaper/exec/wrapper.go
+++ b/subreaper/exec/wrapper.go
@@ -1,0 +1,81 @@
+package exec
+
+import (
+	"fmt"
+	osExec "os/exec"
+	"strconv"
+
+	"github.com/docker/containerd/subreaper"
+)
+
+var ErrNotFound = osExec.ErrNotFound
+
+type Cmd struct {
+	osExec.Cmd
+	err error
+	sub *subreaper.Subscription
+}
+
+type Error struct {
+	Name string
+	Err  error
+}
+
+func (e *Error) Error() string {
+	return "exec: " + strconv.Quote(e.Name) + ": " + e.Err.Error()
+}
+
+type ExitCodeError struct {
+	Code int
+}
+
+func (e ExitCodeError) Error() string {
+	return fmt.Sprintf("Non-zero exit code: %d", e.Code)
+}
+
+func LookPath(file string) (string, error) {
+	v, err := osExec.LookPath(file)
+	return v, translateError(err)
+}
+
+func Command(name string, args ...string) *Cmd {
+	return &Cmd{
+		Cmd: *osExec.Command(name, args...),
+	}
+}
+
+func (c *Cmd) Start() error {
+	c.sub = subreaper.Subscribe()
+	err := c.Cmd.Start()
+	if err != nil {
+		subreaper.Unsubscribe(c.sub)
+		c.sub = nil
+		c.err = translateError(err)
+		return c.err
+	}
+
+	c.sub.SetPid(c.Cmd.Process.Pid)
+	return nil
+}
+
+func (c *Cmd) Wait() error {
+	if c.sub == nil {
+		return c.err
+	}
+	exitCode := c.sub.Wait()
+	if exitCode == 0 {
+		return nil
+	}
+	return ExitCodeError{Code: exitCode}
+}
+
+func translateError(err error) error {
+	switch v := err.(type) {
+	case *osExec.Error:
+		return &Error{
+			Name: v.Name,
+			Err:  v.Err,
+		}
+	}
+	return err
+}

--- a/subreaper/reaper.go
+++ b/subreaper/reaper.go
@@ -31,6 +31,7 @@ func (s *Subscription) SetPid(pid int) {
 				s.exit = exit
 				s.wg.Done()
 				Unsubscribe(s)
+				break
 			}
 		}
 	}()
@@ -61,7 +62,10 @@ func Unsubscribe(sub *Subscription) {
 	subLock.Lock()
 	defer subLock.Unlock()
 
-	delete(subscriptions, sub.id)
+	if _, ok := subscriptions[sub.id]; ok {
+		close(sub.c)
+		delete(subscriptions, sub.id)
+	}
 }
 
 func Start() error {

--- a/subreaper/reaper.go
+++ b/subreaper/reaper.go
@@ -1,0 +1,102 @@
+package subreaper
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/containerd/osutils"
+)
+
+var (
+	subscriptions = map[int]*Subscription{}
+	subLock       = sync.Mutex{}
+	counter       = 0
+	once          = sync.Once{}
+)
+
+type Subscription struct {
+	id   int
+	exit osutils.Exit
+	c    chan osutils.Exit
+	wg   sync.WaitGroup
+}
+
+func (s *Subscription) SetPid(pid int) {
+	go func() {
+		for exit := range s.c {
+			if exit.Pid == pid {
+				s.exit = exit
+				s.wg.Done()
+				Unsubscribe(s)
+			}
+		}
+	}()
+}
+
+func (s *Subscription) Wait() int {
+	s.wg.Wait()
+	return s.exit.Status
+}
+
+func Subscribe() *Subscription {
+	subLock.Lock()
+	defer subLock.Unlock()
+
+	Start()
+
+	counter++
+	s := &Subscription{
+		id: counter,
+		c:  make(chan osutils.Exit, 1024),
+	}
+	s.wg.Add(1)
+	subscriptions[s.id] = s
+	return s
+}
+
+func Unsubscribe(sub *Subscription) {
+	subLock.Lock()
+	defer subLock.Unlock()
+
+	delete(subscriptions, sub.id)
+}
+
+func Start() error {
+	var err error
+	once.Do(func() {
+		err = osutils.SetSubreaper(1)
+		if err != nil {
+			return
+		}
+
+		s := make(chan os.Signal, 2048)
+		signal.Notify(s, syscall.SIGCHLD)
+		go childReaper(s)
+	})
+
+	return err
+}
+
+func childReaper(s chan os.Signal) {
+	for range s {
+		exits, err := osutils.Reap()
+		if err == nil {
+			notify(exits)
+		} else {
+			logrus.WithField("error", err).Warn("containerd: reap child processes")
+		}
+	}
+}
+
+func notify(exits []osutils.Exit) {
+	subLock.Lock()
+	for _, exit := range exits {
+		for _, sub := range subscriptions {
+			sub.c <- exit
+		}
+	}
+	subLock.Unlock()
+}

--- a/supervisor/sort_test.go
+++ b/supervisor/sort_test.go
@@ -61,10 +61,6 @@ func (p *testProcess) State() runtime.State {
 	return runtime.Running
 }
 
-func (p *testProcess) Wait() {
-
-}
-
 func TestSortProcesses(t *testing.T) {
 	p := []runtime.Process{
 		&testProcess{"ls"},

--- a/supervisor/sort_test.go
+++ b/supervisor/sort_test.go
@@ -61,6 +61,10 @@ func (p *testProcess) State() runtime.State {
 	return runtime.Running
 }
 
+func (p *testProcess) Start() error {
+	return nil
+}
+
 func TestSortProcesses(t *testing.T) {
 	p := []runtime.Process{
 		&testProcess{"ls"},

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -274,7 +274,6 @@ func (s *Supervisor) SendTask(evt Task) {
 
 func (s *Supervisor) exitHandler() {
 	for p := range s.monitor.Exits() {
-		p.Wait()
 		e := &ExitTask{
 			Process: p,
 		}


### PR DESCRIPTION
The shim serves a good purpose as middle management, allowing the leader to take a vacation and resume her job later uninterrupted.  But, you know, sometimes if your leader wants to drink the koolaid and die, you die too, and it's all right.  There's some good practical reasons that the overhead of the shim aren't desired, regardless of how small it may be.  Another process, more memory, more piping I/O, etc.

~~I've got this PR mostly working but there is one big design issue I encountered.  You'll notice it immediately in the diff in main.go.  In order to get the exit status and record it to the `exitStatus` file, one must actually obtain that status :smile:.  This means in the new `direct_process.go` implementation that I've added I must do a `WaitPid4` to get the exit status.  If I do this I run into a conflict with the `WaitPid4(-1)` that runs from `main.go` on `SIGCHLD`.  This means in order for these two things work they must cooperate with each other.  Now this could be done by registering some type of handler to the SIGCHLD handling loop.  The design issue I run into is how to do that.  I could just create something at the package level.  So some package level variable that stores handlers, or create some new object and pass it down through the layers.  I opt for the first approach.~~

Please let me know which approach you think might be better.  Also let me know if this whole thing is just stupid.  From what I've seen so far, I don't see any fundamental problems, just need to work through a couple more kinks.