### PR TITLE
uprev dependencies required for build clean on Solaris

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -9,7 +9,7 @@ clone git github.com/cloudfoundry/gosigar 3ed7c74352dae6dc00bdc8c74045375352e3ec
 clone git github.com/codegangsta/cli 9fec0fad02befc9209347cc6d620e68e1b45f74d
 clone git github.com/coreos/go-systemd 7b2428fec40033549c68f54e26e89e7ca9a9ce31
 clone git github.com/cyberdelia/go-metrics-graphite 7e54b5c2aa6eaff4286c44129c3def899dff528c
-clone git github.com/docker/docker f3dcc1c46249ffc4a73ab2005d1ad011dff3c7df
+clone git github.com/docker/docker 2f6e3b0ba027b558adabd41344fee59db4441011
 clone git github.com/docker/go-units 5d2041e26a699eaca682e2ea41c8f891e1060444
 clone git github.com/godbus/dbus e2cf28118e66a6a63db46cf6088a35d2054d3bb0
 clone git github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998

--- a/vendor/src/github.com/docker/docker/pkg/term/tc_other.go
+++ b/vendor/src/github.com/docker/docker/pkg/term/tc_other.go
@@ -1,5 +1,6 @@
 // +build !windows
 // +build !linux !cgo
+// +build !solaris !cgo
 
 package term
 

--- a/vendor/src/github.com/docker/docker/pkg/term/term.go
+++ b/vendor/src/github.com/docker/docker/pkg/term/term.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"unsafe"
 )
 
 var (
@@ -27,6 +26,8 @@ type State struct {
 type Winsize struct {
 	Height uint16
 	Width  uint16
+	x      uint16
+	y      uint16
 }
 
 // StdStreams returns the standard streams (stdin, stdout, stedrr).
@@ -43,27 +44,6 @@ func GetFdInfo(in interface{}) (uintptr, bool) {
 		isTerminalIn = IsTerminal(inFd)
 	}
 	return inFd, isTerminalIn
-}
-
-// GetWinsize returns the window size based on the specified file descriptor.
-func GetWinsize(fd uintptr) (*Winsize, error) {
-	ws := &Winsize{}
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
-	// Skip errno = 0
-	if err == 0 {
-		return ws, nil
-	}
-	return ws, err
-}
-
-// SetWinsize tries to set the specified window size for the specified file descriptor.
-func SetWinsize(fd uintptr, ws *Winsize) error {
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
-	// Skip errno = 0
-	if err == 0 {
-		return nil
-	}
-	return err
 }
 
 // IsTerminal returns true if the given file descriptor is a terminal.

--- a/vendor/src/github.com/docker/docker/pkg/term/term_solaris.go
+++ b/vendor/src/github.com/docker/docker/pkg/term/term_solaris.go
@@ -1,0 +1,41 @@
+// +build solaris
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+/*
+#include <unistd.h>
+#include <stropts.h>
+#include <termios.h>
+
+// Small wrapper to get rid of variadic args of ioctl()
+int my_ioctl(int fd, int cmd, struct winsize *ws) {
+	return ioctl(fd, cmd, ws);
+}
+*/
+import "C"
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	ws := &Winsize{}
+	ret, err := C.my_ioctl(C.int(fd), C.int(syscall.TIOCGWINSZ), (*C.struct_winsize)(unsafe.Pointer(ws)))
+	// Skip retval = 0
+	if ret == 0 {
+		return ws, nil
+	}
+	return ws, err
+}
+
+// SetWinsize tries to set the specified window size for the specified file descriptor.
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	ret, err := C.my_ioctl(C.int(fd), C.int(syscall.TIOCSWINSZ), (*C.struct_winsize)(unsafe.Pointer(ws)))
+	// Skip retval = 0
+	if ret == 0 {
+		return nil
+	}
+	return err
+}

--- a/vendor/src/github.com/docker/docker/pkg/term/term_unix.go
+++ b/vendor/src/github.com/docker/docker/pkg/term/term_unix.go
@@ -1,0 +1,29 @@
+// +build !solaris,!windows
+
+package term
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// GetWinsize returns the window size based on the specified file descriptor.
+func GetWinsize(fd uintptr) (*Winsize, error) {
+	ws := &Winsize{}
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
+	// Skipp errno = 0
+	if err == 0 {
+		return ws, nil
+	}
+	return ws, err
+}
+
+// SetWinsize tries to set the specified window size for the specified file descriptor.
+func SetWinsize(fd uintptr, ws *Winsize) error {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
+	// Skipp errno = 0
+	if err == 0 {
+		return nil
+	}
+	return err
+}

--- a/vendor/src/github.com/docker/docker/pkg/term/windows/ansi_reader.go
+++ b/vendor/src/github.com/docker/docker/pkg/term/windows/ansi_reader.go
@@ -136,14 +136,14 @@ func readInputEvents(fd uintptr, maxBytes int) ([]winterm.INPUT_RECORD, error) {
 
 // KeyEvent Translation Helpers
 
-var arrowKeyMapPrefix = map[winterm.WORD]string{
+var arrowKeyMapPrefix = map[uint16]string{
 	winterm.VK_UP:    "%s%sA",
 	winterm.VK_DOWN:  "%s%sB",
 	winterm.VK_RIGHT: "%s%sC",
 	winterm.VK_LEFT:  "%s%sD",
 }
 
-var keyMapPrefix = map[winterm.WORD]string{
+var keyMapPrefix = map[uint16]string{
 	winterm.VK_UP:     "\x1B[%sA",
 	winterm.VK_DOWN:   "\x1B[%sB",
 	winterm.VK_RIGHT:  "\x1B[%sC",
@@ -207,7 +207,7 @@ func keyToString(keyEvent *winterm.KEY_EVENT_RECORD, escapeSequence []byte) stri
 }
 
 // formatVirtualKey converts a virtual key (e.g., up arrow) into the appropriate ANSI string.
-func formatVirtualKey(key winterm.WORD, controlState winterm.DWORD, escapeSequence []byte) string {
+func formatVirtualKey(key uint16, controlState uint32, escapeSequence []byte) string {
 	shift, alt, control := getControlKeys(controlState)
 	modifier := getControlKeysModifier(shift, alt, control)
 
@@ -223,7 +223,7 @@ func formatVirtualKey(key winterm.WORD, controlState winterm.DWORD, escapeSequen
 }
 
 // getControlKeys extracts the shift, alt, and ctrl key states.
-func getControlKeys(controlState winterm.DWORD) (shift, alt, control bool) {
+func getControlKeys(controlState uint32) (shift, alt, control bool) {
 	shift = 0 != (controlState & winterm.SHIFT_PRESSED)
 	alt = 0 != (controlState & (winterm.LEFT_ALT_PRESSED | winterm.RIGHT_ALT_PRESSED))
 	control = 0 != (controlState & (winterm.LEFT_CTRL_PRESSED | winterm.RIGHT_CTRL_PRESSED))

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/console_solaris.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/console_solaris.go
@@ -1,0 +1,11 @@
+package libcontainer
+
+import (
+	"errors"
+)
+
+// NewConsole returns an initalized console that can be used within a container by copying bytes
+// from the master side to the slave that is attached as the tty for the container's init process.
+func NewConsole(uid, gid int) (Console, error) {
+	return nil, errors.New("libcontainer console is not supported on Solaris")
+}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/container_solaris.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/container_solaris.go
@@ -1,0 +1,20 @@
+package libcontainer
+
+// State represents a running container's state
+type State struct {
+	BaseState
+
+	// Platform specific fields below here
+}
+
+// A libcontainer container object.
+//
+// Each container is thread-safe within the same process. Since a container can
+// be destroyed by a separate process, any function may return that the container
+// was not found.
+type Container interface {
+	BaseContainer
+
+	// Methods below here are platform specific
+
+}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/stats_solaris.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/stats_solaris.go
@@ -1,0 +1,7 @@
+package libcontainer
+
+// Solaris - TODO
+
+type Stats struct {
+	Interfaces []*NetworkInterface
+}


### PR DESCRIPTION
This PR uprevs pkg/term and runc/libcontainer in containerd such that they build on Solaris.
This is a dependency for #203.

Signed-off-by: Amit Krishnan <krish.amit@gmail.com>