### PR TITLE
Fix ctr file leak and exec after restore

### DIFF
--- a/ctr/container.go
+++ b/ctr/container.go
@@ -164,6 +164,11 @@ var startCommand = cli.Command{
 			fatal(fmt.Sprintf("cannot get the absolute path of the bundle: %v", err), 1)
 		}
 		s, err := createStdio()
+		defer func() {
+			if s.stdin != "" {
+				os.RemoveAll(filepath.Dir(s.stdin))
+			}
+		}()
 		if err != nil {
 			fatal(err.Error(), 1)
 		}
@@ -463,6 +468,11 @@ var execCommand = cli.Command{
 			},
 		}
 		s, err := createStdio()
+		defer func() {
+			if s.stdin != "" {
+				os.RemoveAll(filepath.Dir(s.stdin))
+			}
+		}()
 		if err != nil {
 			fatal(err.Error(), 1)
 		}

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -138,7 +138,7 @@ func New(opts ContainerOpts) (Container, error) {
 	return c, nil
 }
 
-func Load(root, id string) (Container, error) {
+func Load(root, id string, timeout time.Duration) (Container, error) {
 	var s state
 	f, err := os.Open(filepath.Join(root, id, StateFile))
 	if err != nil {
@@ -158,6 +158,7 @@ func Load(root, id string) (Container, error) {
 		shim:        s.Shim,
 		noPivotRoot: s.NoPivotRoot,
 		processes:   make(map[string]*process),
+		timeout:     timeout,
 	}
 	dirs, err := ioutil.ReadDir(filepath.Join(root, id))
 	if err != nil {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -130,6 +130,7 @@ func New(opts ContainerOpts) (Container, error) {
 		Labels:      c.labels,
 		Runtime:     c.runtime,
 		RuntimeArgs: c.runtimeArgs,
+		Shim:        c.shim,
 		NoPivotRoot: opts.NoPivotRoot,
 	}); err != nil {
 		return nil, err

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -305,7 +305,7 @@ func (s *Supervisor) restore() error {
 			continue
 		}
 		id := d.Name()
-		container, err := runtime.Load(s.stateDir, id)
+		container, err := runtime.Load(s.stateDir, id, s.timeout)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
* Fix restore to correctly set the exec timeout value (containerd)
* Add missing shim value when saving container state.json (containerd)
* Cleanup stdio files upon start and exec termination (ctr).