### PR TITLE
Makefile improv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,3 +47,5 @@ RUN set -x \
 COPY . /go/src/github.com/docker/containerd
 
 WORKDIR /go/src/github.com/docker/containerd
+
+RUN make all install

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ lint:
 shell: dbuild
 	$(DOCKER_RUN) bash
 
-test: all validate
+test: validate
 	go test -v $(shell go list ./... | grep -v /vendor | grep -v /integration-test)
 ifneq ($(wildcard /.dockerenv), )
 	$(MAKE) install bundles-rootfs


### PR DESCRIPTION
Closes #239

- Automatically build and install containerd binaries within the generate docker image
- Removed unneeded compilation when running `make test` 