### PR TITLE
Micro benchmarks for containerd.

### DIFF
--- a/integration-test/bundle_utils_test.go
+++ b/integration-test/bundle_utils_test.go
@@ -8,12 +8,8 @@ import (
 	"path/filepath"
 	"reflect"
 
+	utils "github.com/docker/containerd/testutils"
 	ocs "github.com/opencontainers/runtime-spec/specs-go"
-)
-
-var (
-	bundlesDir      = filepath.Join("test-artifacts", "oci-bundles")
-	refOciSpecsPath = filepath.Join(bundlesDir, "config.json")
 )
 
 type OciProcessArgs struct {
@@ -48,7 +44,7 @@ func untarRootfs(source string, destination string) error {
 func CreateBundleWithFilter(source, name string, args []string, filter func(spec *ocs.Spec)) error {
 	// Generate the spec
 	var spec ocs.Spec
-	if f, err := os.Open(refOciSpecsPath); err != nil {
+	if f, err := os.Open(utils.RefOciSpecsPath); err != nil {
 		return fmt.Errorf("Failed to open default spec: %v", err)
 	} else {
 		if err := json.NewDecoder(f).Decode(&spec); err != nil {
@@ -63,7 +59,7 @@ func CreateBundleWithFilter(source, name string, args []string, filter func(spec
 		filter(&spec)
 	}
 
-	bundlePath := filepath.Join(bundlesDir, name)
+	bundlePath := filepath.Join(utils.BundlesRoot, name)
 	nb := Bundle{source, name, spec, bundlePath}
 
 	// Check that we don't already have such a bundle
@@ -78,7 +74,7 @@ func CreateBundleWithFilter(source, name string, args []string, filter func(spec
 	// Nothing should be there, but just in case
 	os.RemoveAll(bundlePath)
 
-	if err := untarRootfs(filepath.Join(archivesDir, source+".tar"), bundlePath); err != nil {
+	if err := untarRootfs(filepath.Join(utils.ArchivesDir, source+".tar"), bundlePath); err != nil {
 		return fmt.Errorf("Failed to untar %s.tar: %v", source, err)
 	}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1,0 +1,174 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	utils "github.com/docker/containerd/testutils"
+)
+
+var (
+	devNull = "/dev/null"
+	stdin   io.WriteCloser
+)
+
+// Create containerd state and oci bundles directory
+func setup() error {
+	if err := os.MkdirAll(utils.StateDir, 0755); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(utils.BundlesRoot, 0755); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Creates the bundleDir with rootfs, io fifo dir and a default spec.
+// On success, returns the bundlePath
+func setupBundle(bundleName string) (string, error) {
+	bundlePath := filepath.Join(utils.BundlesRoot, bundleName)
+	if err := os.MkdirAll(bundlePath, 0755); err != nil {
+		fmt.Println("Unable to create bundlePath due to ", err)
+		return "", err
+	}
+
+	io := filepath.Join(bundlePath, "io")
+	if err := os.MkdirAll(io, 0755); err != nil {
+		fmt.Println("Unable to create io dir due to ", err)
+		return "", err
+	}
+
+	if err := utils.GenerateReferenceSpecs(bundlePath); err != nil {
+		fmt.Println("Unable to generate OCI reference spec: ", err)
+		return "", err
+	}
+
+	if err := utils.CreateBusyboxBundle(bundleName); err != nil {
+		fmt.Println("CreateBusyboxBundle error: ", err)
+		return "", err
+	}
+
+	return bundlePath, nil
+}
+
+func setupStdio(cwd string, bundlePath string, bundleName string) (Stdio, error) {
+	s := NewStdio(devNull, devNull, devNull)
+
+	pid := "init"
+	for stdName, stdPath := range map[string]*string{
+		"stdin":  &s.Stdin,
+		"stdout": &s.Stdout,
+		"stderr": &s.Stderr,
+	} {
+		*stdPath = filepath.Join(cwd, bundlePath, "io", bundleName+"-"+pid+"-"+stdName)
+		if err := syscall.Mkfifo(*stdPath, 0755); err != nil && !os.IsExist(err) {
+			fmt.Println("Mkfifo error: ", err)
+			return s, err
+		}
+	}
+
+	err := attachStdio(s)
+	if err != nil {
+		fmt.Println("attachStdio error: ", err)
+		return s, err
+	}
+
+	return s, nil
+}
+
+func attachStdio(s Stdio) error {
+	stdinf, err := os.OpenFile(s.Stdin, syscall.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	stdin = stdinf
+	stdoutf, err := os.OpenFile(s.Stdout, syscall.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	go io.Copy(os.Stdout, stdoutf)
+	stderrf, err := os.OpenFile(s.Stderr, syscall.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	go io.Copy(os.Stderr, stderrf)
+	return nil
+}
+
+func teardownBundle(bundleName string) {
+	containerRoot := filepath.Join(utils.StateDir, bundleName)
+	os.RemoveAll(containerRoot)
+
+	bundlePath := filepath.Join(utils.BundlesRoot, bundleName)
+	os.RemoveAll(bundlePath)
+	return
+}
+
+// Remove containerd state and oci bundles directory
+func teardown() {
+	os.RemoveAll(utils.StateDir)
+	os.RemoveAll(utils.BundlesRoot)
+}
+
+func BenchmarkBusyboxSh(b *testing.B) {
+	bundleName := "busybox-sh"
+
+	wd := utils.GetTestOutDir()
+	if err := os.Chdir(wd); err != nil {
+		b.Fatalf("Could not change working directory: %v", err)
+	}
+
+	if err := setup(); err != nil {
+		b.Fatalf("Error setting up test: %v", err)
+	}
+	defer teardown()
+
+	for n := 0; n < b.N; n++ {
+		bundlePath, err := setupBundle(bundleName)
+		if err != nil {
+			return
+		}
+
+		s, err := setupStdio(wd, bundlePath, bundleName)
+		if err != nil {
+			return
+		}
+
+		c, err := New(ContainerOpts{
+			Root:    utils.StateDir,
+			ID:      bundleName,
+			Bundle:  filepath.Join(wd, bundlePath),
+			Runtime: "runc",
+			Shim:    "containerd-shim",
+			Timeout: 15 * time.Second,
+		})
+
+		if err != nil {
+			b.Fatalf("Error creating a New container: ", err)
+		}
+
+		benchmarkStartContainer(b, c, s, bundleName)
+
+		teardownBundle(bundleName)
+	}
+}
+
+func benchmarkStartContainer(b *testing.B, c Container, s Stdio, bundleName string) {
+	if _, err := c.Start("", s); err != nil {
+		b.Fatalf("Error starting container %v", err)
+	}
+
+	kill := exec.Command("runc", "kill", bundleName, "KILL")
+	kill.Run()
+
+	// wait for kill to finish. selected wait time is arbitrary
+	time.Sleep(500 * time.Millisecond)
+
+}

--- a/testutils/testutils.go
+++ b/testutils/testutils.go
@@ -1,0 +1,60 @@
+package testutils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Output directory for testing and benchmark artifacts
+func GetTestOutDir() string {
+	out, _ := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	repoRoot := string(out)
+	prefix := filepath.Join(strings.TrimSpace(repoRoot), "output")
+	return prefix
+}
+
+var (
+	ArchivesDir     = filepath.Join("test-artifacts", "archives")
+	BundlesRoot     = filepath.Join("test-artifacts", "oci-bundles")
+	OutputDirFormat = filepath.Join("test-artifacts", "runs", "%s")
+	RefOciSpecsPath = filepath.Join(BundlesRoot, "config.json")
+	StateDir        = "/run/containerd-bench-test"
+)
+
+// untarRootfs untars the given `source` tarPath into `destination/rootfs`
+func untarRootfs(source string, destination string) error {
+	rootfs := filepath.Join(destination, "rootfs")
+
+	if err := os.MkdirAll(rootfs, 0755); err != nil {
+		fmt.Println("untarRootfs os.MkdirAll failed with err %v", err)
+		return nil
+	}
+	tar := exec.Command("tar", "-C", rootfs, "-xf", source)
+	return tar.Run()
+}
+
+func GenerateReferenceSpecs(destination string) error {
+	if _, err := os.Stat(filepath.Join(destination, "config.json")); err == nil {
+		return nil
+	}
+	specs := exec.Command("runc", "spec")
+	specs.Dir = destination
+	return specs.Run()
+}
+
+func CreateBundle(source, name string) error {
+	bundlePath := filepath.Join(BundlesRoot, name)
+
+	if err := untarRootfs(filepath.Join(ArchivesDir, source+".tar"), bundlePath); err != nil {
+		return fmt.Errorf("Failed to untar %s.tar: %v", source, err)
+	}
+
+	return nil
+}
+
+func CreateBusyboxBundle(name string) error {
+	return CreateBundle("busybox", name)
+}


### PR DESCRIPTION
This is the first in a series of micro benchmarks for containerd.
Performance measurement will use containerd objects and methods
that are not dependent on the grpc API and dont require the daemon
to the running. Test will require containerd-shim and runc.

The motivation is to understand the baseline performance at the lowest
containerd layer. A natural extension to this effort would be to write
macro benchmarks which would include API and daemon.

Note:
- Currently measures only one workload (busybox sh) start times. Will
add other bundles and args soon.
- Can use integration-test utils for bundle processing. However, json
marshal/unmarshal is currently timing out standard benchmark times. So
going with default spec for now.

Sample run:
BenchmarkBusyboxSh-4    / # / # / #        2     576013841 ns/op
ok      github.com/docker/containerd/runtime    1.800s

Signed-off-by: Anusha Ragunathan <anusha@docker.com>