### PR TITLE
The Return of Containerd the Zombie Slayer

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -131,7 +131,10 @@ func daemon(context *cli.Context) error {
 	// setup a standard reaper so that we don't leave any zombies if we are still alive
 	// this is just good practice because we are spawning new processes
 	s := make(chan os.Signal, 2048)
-	signal.Notify(s, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(s, syscall.SIGCHLD, syscall.SIGTERM, syscall.SIGINT)
+	if err := osutils.SetSubreaper(1); err != nil {
+		logrus.WithField("error", err).Error("containerd: set subpreaper")
+	}
 	sv, err := supervisor.New(
 		context.String("state-dir"),
 		context.String("runtime"),
@@ -163,6 +166,10 @@ func daemon(context *cli.Context) error {
 	}
 	for ss := range s {
 		switch ss {
+		case syscall.SIGCHLD:
+			if _, err := osutils.Reap(); err != nil {
+				logrus.WithField("error", err).Warn("containerd: reap child processes")
+			}
 		default:
 			logrus.Infof("stopping containerd after receiving %s", ss)
 			server.Stop()

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/containerd/specs"
+	"github.com/docker/containerd/subreaper/exec"
 	ocs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -452,7 +452,6 @@ func (c *container) Exec(pid string, pspec specs.ProcessSpec, s Stdio) (pp Proce
 }
 
 func (c *container) startCmd(pid string, cmd *exec.Cmd, p *process) error {
-	p.cmd = cmd
 	if err := cmd.Start(); err != nil {
 		if exErr, ok := err.(*exec.Error); ok {
 			if exErr.Err == exec.ErrNotFound || exErr.Err == os.ErrNotExist {
@@ -613,9 +612,6 @@ func (c *container) waitForStart(p *process, cmd *exec.Cmd) error {
 
 // isAlive checks if the shim that launched the container is still alive
 func isAlive(cmd *exec.Cmd) (bool, error) {
-	if _, err := syscall.Wait4(cmd.Process.Pid, nil, syscall.WNOHANG, nil); err == nil {
-		return true, nil
-	}
 	if err := syscall.Kill(cmd.Process.Pid, 0); err != nil {
 		if err == syscall.ESRCH {
 			return false, nil

--- a/runtime/process.go
+++ b/runtime/process.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -41,8 +40,6 @@ type Process interface {
 	SystemPid() int
 	// State returns if the process is running or not
 	State() State
-	// Wait reaps the shim process if avaliable
-	Wait()
 }
 
 type processConfig struct {
@@ -143,7 +140,6 @@ type process struct {
 	container   *container
 	spec        specs.ProcessSpec
 	stdio       Stdio
-	cmd         *exec.Cmd
 }
 
 func (p *process) ID() string {
@@ -222,13 +218,6 @@ func (p *process) getPidFromFile() (int, error) {
 	}
 	p.pid = i
 	return i, nil
-}
-
-// Wait will reap the shim process
-func (p *process) Wait() {
-	if p.cmd != nil {
-		p.cmd.Wait()
-	}
 }
 
 func getExitPipe(path string) (*os.File, error) {

--- a/subreaper/exec/copy.go
+++ b/subreaper/exec/copy.go
@@ -1,0 +1,54 @@
+package exec
+
+import (
+	"bytes"
+	"errors"
+)
+
+// Below is largely a copy from go's os/exec/exec.go
+
+// Run starts the specified command and waits for it to complete.
+//
+// The returned error is nil if the command runs, has no problems
+// copying stdin, stdout, and stderr, and exits with a zero exit
+// status.
+//
+// If the command fails to run or doesn't complete successfully, the
+// error is of type *ExitError. Other error types may be
+// returned for I/O problems.
+func (c *Cmd) Run() error {
+	if err := c.Start(); err != nil {
+		return translateError(err)
+	}
+	return translateError(c.Wait())
+}
+
+// Output runs the command and returns its standard output.
+// Any returned error will usually be of type *ExitError.
+// If c.Stderr was nil, Output populates ExitError.Stderr.
+func (c *Cmd) Output() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	var stdout bytes.Buffer
+	c.Stdout = &stdout
+
+	err := c.Run()
+	return stdout.Bytes(), err
+}
+
+// CombinedOutput runs the command and returns its combined standard
+// output and standard error.
+func (c *Cmd) CombinedOutput() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	if c.Stderr != nil {
+		return nil, errors.New("exec: Stderr already set")
+	}
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+	err := c.Run()
+	return b.Bytes(), err
+}

--- a/subreaper/exec/wrapper.go
+++ b/subreaper/exec/wrapper.go
@@ -1,0 +1,81 @@
+package exec
+
+import (
+	"fmt"
+	osExec "os/exec"
+	"strconv"
+
+	"github.com/docker/containerd/subreaper"
+)
+
+var ErrNotFound = osExec.ErrNotFound
+
+type Cmd struct {
+	osExec.Cmd
+	err error
+	sub *subreaper.Subscription
+}
+
+type Error struct {
+	Name string
+	Err  error
+}
+
+func (e *Error) Error() string {
+	return "exec: " + strconv.Quote(e.Name) + ": " + e.Err.Error()
+}
+
+type ExitCodeError struct {
+	Code int
+}
+
+func (e ExitCodeError) Error() string {
+	return fmt.Sprintf("Non-zero exit code: %d", e.Code)
+}
+
+func LookPath(file string) (string, error) {
+	v, err := osExec.LookPath(file)
+	return v, translateError(err)
+}
+
+func Command(name string, args ...string) *Cmd {
+	return &Cmd{
+		Cmd: *osExec.Command(name, args...),
+	}
+}
+
+func (c *Cmd) Start() error {
+	c.sub = subreaper.Subscribe()
+	err := c.Cmd.Start()
+	if err != nil {
+		subreaper.Unsubscribe(c.sub)
+		c.sub = nil
+		c.err = translateError(err)
+		return c.err
+	}
+
+	c.sub.SetPid(c.Cmd.Process.Pid)
+	return nil
+}
+
+func (c *Cmd) Wait() error {
+	if c.sub == nil {
+		return c.err
+	}
+	exitCode := c.sub.Wait()
+	if exitCode == 0 {
+		return nil
+	}
+	return ExitCodeError{Code: exitCode}
+}
+
+func translateError(err error) error {
+	switch v := err.(type) {
+	case *osExec.Error:
+		return &Error{
+			Name: v.Name,
+			Err:  v.Err,
+		}
+	}
+	return err
+}

--- a/subreaper/reaper.go
+++ b/subreaper/reaper.go
@@ -1,0 +1,102 @@
+package subreaper
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/containerd/osutils"
+)
+
+var (
+	subscriptions = map[int]*Subscription{}
+	subLock       = sync.Mutex{}
+	counter       = 0
+	once          = sync.Once{}
+)
+
+type Subscription struct {
+	id   int
+	exit osutils.Exit
+	c    chan osutils.Exit
+	wg   sync.WaitGroup
+}
+
+func (s *Subscription) SetPid(pid int) {
+	go func() {
+		for exit := range s.c {
+			if exit.Pid == pid {
+				s.exit = exit
+				s.wg.Done()
+				Unsubscribe(s)
+			}
+		}
+	}()
+}
+
+func (s *Subscription) Wait() int {
+	s.wg.Wait()
+	return s.exit.Status
+}
+
+func Subscribe() *Subscription {
+	subLock.Lock()
+	defer subLock.Unlock()
+
+	Start()
+
+	counter++
+	s := &Subscription{
+		id: counter,
+		c:  make(chan osutils.Exit, 1024),
+	}
+	s.wg.Add(1)
+	subscriptions[s.id] = s
+	return s
+}
+
+func Unsubscribe(sub *Subscription) {
+	subLock.Lock()
+	defer subLock.Unlock()
+
+	delete(subscriptions, sub.id)
+}
+
+func Start() error {
+	var err error
+	once.Do(func() {
+		err = osutils.SetSubreaper(1)
+		if err != nil {
+			return
+		}
+
+		s := make(chan os.Signal, 2048)
+		signal.Notify(s, syscall.SIGCHLD)
+		go childReaper(s)
+	})
+
+	return err
+}
+
+func childReaper(s chan os.Signal) {
+	for range s {
+		exits, err := osutils.Reap()
+		if err == nil {
+			notify(exits)
+		} else {
+			logrus.WithField("error", err).Warn("containerd: reap child processes")
+		}
+	}
+}
+
+func notify(exits []osutils.Exit) {
+	subLock.Lock()
+	for _, exit := range exits {
+		for _, sub := range subscriptions {
+			sub.c <- exit
+		}
+	}
+	subLock.Unlock()
+}

--- a/supervisor/sort_test.go
+++ b/supervisor/sort_test.go
@@ -61,10 +61,6 @@ func (p *testProcess) State() runtime.State {
 	return runtime.Running
 }
 
-func (p *testProcess) Wait() {
-
-}
-
 func TestSortProcesses(t *testing.T) {
 	p := []runtime.Process{
 		&testProcess{"ls"},

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -274,7 +274,6 @@ func (s *Supervisor) SendTask(evt Task) {
 
 func (s *Supervisor) exitHandler() {
 	for p := range s.monitor.Exits() {
-		p.Wait()
 		e := &ExitTask{
 			Process: p,
 		}


### PR DESCRIPTION
One can not use os/exec and syscall.WaitPid4(-1,...) at the same time as it will cause a race condition on which goroutine will receive the SIGCHLD. This commit introduces a os/exec API compatible package that can be used to allow containerd to do generic SIGCHLD reaping and do cmd.Wait() calls.

I need `containerd` to be a subreaper in order for a shimless version of containerd to work.  The reason being that containerd will spawn runc, which spawns the container process, and then dies.  The container process needs to be a child of containerd after runc dies in order to get the exit code.