### PR TITLE
Store the checkpoint and restore logs in the same directory as the checkpoint image

### DIFF
--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -132,7 +132,8 @@ func (p *process) start() error {
 		)
 	} else if p.checkpoint != nil {
 		args = append(args, "restore",
-			"--image-path", filepath.Join(p.checkpointPath),
+			"--image-path", p.checkpointPath,
+			"--work-path", filepath.Join(p.checkpointPath, "criu.work", "restore-"+time.Now().Format(time.RFC3339)),
 		)
 		add := func(flags ...string) {
 			args = append(args, flags...)

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -344,6 +344,7 @@ func (c *container) Checkpoint(cpt Checkpoint, checkpointDir string) error {
 	args := []string{
 		"checkpoint",
 		"--image-path", path,
+		"--work-path", filepath.Join(path, "criu.work"),
 	}
 	add := func(flags ...string) {
 		args = append(args, flags...)


### PR DESCRIPTION
Currently the storage defaults to a /runc managed directory that is usually destroyed, making the logs difficult to get. This just stores them in the same path as the rest of the checkpoint files (which also makes things easier at the Docker level, which destroys the containerd managed folder).