### PR TITLE
Wait for runtime start command to finish

### DIFF
--- a/integration-test/check_test.go
+++ b/integration-test/check_test.go
@@ -192,7 +192,7 @@ func (cs *ContainerdSuite) SetUpSuite(c *check.C) {
 	// Create our output directory
 	cs.outputDir = fmt.Sprintf(utils.OutputDirFormat, time.Now().Format("2006-01-02_150405.000000"))
 
-	cs.stateDir = filepath.Join(cs.outputDir, "containerd-master")
+	cs.stateDir = filepath.Join(cs.cwd, cs.outputDir, "containerd-master")
 	if err := os.MkdirAll(cs.stateDir, 0755); err != nil {
 		c.Fatalf("Unable to created output directory '%s': %v", cs.stateDir, err)
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -38,6 +38,8 @@ const (
 	StateFile = "state.json"
 	// ControlFile holds the name of the pipe used to control the shim
 	ControlFile = "control"
+	// StartSyncFile holds the name of the pipe used to sync with the `start` oci command
+	StartSyncFile = "startSync"
 	// InitProcessID holds the special ID used for the very first
 	// container's process
 	InitProcessID = "init"


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

We need to wait for the shim call to `runc start` to be over before returning from `containerd` to avoid a race where one assume the user process has already been `exec`.

I don't like this design much, but we can't use a unix socket to replace the control pipe as that would prevent restoring.

any better idea @crosbymichael ?