### PR TITLE
Call start in containerd

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -136,13 +136,6 @@ func start(log *os.File) error {
 					Height: uint16(msg.Height),
 				}
 				term.SetWinsize(p.console.Fd(), &ws)
-			case 2:
-				// tell runtime to execute the init process
-				if err := p.start(); err != nil {
-					p.delete()
-					p.Wait()
-					return err
-				}
 			}
 		}
 	}

--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -206,26 +206,6 @@ func (p *process) create() error {
 	return nil
 }
 
-func (p *process) start() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	logPath := filepath.Join(cwd, "log.json")
-	args := append([]string{
-		"--log", logPath,
-		"--log-format", "json",
-	}, p.state.RuntimeArgs...)
-	args = append(args, "start", p.id)
-	cmd := exec.Command(p.runtime, args...)
-	cmd.Dir = p.bundle
-	cmd.Stdin = p.stdio.stdin
-	cmd.Stdout = p.stdio.stdout
-	cmd.Stderr = p.stdio.stderr
-	cmd.SysProcAttr = setPDeathSig()
-	return cmd.Run()
-}
-
 func (p *process) pid() int {
 	return p.containerPid
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -20,6 +20,9 @@ var (
 	// ErrContainerStartTimeout is returned if a container takes too
 	// long to start
 	ErrContainerStartTimeout = errors.New("containerd: container did not start before the specified timeout")
+	// ErrShimExited is returned if the shim or the contianer's init process
+	// exits before completing
+	ErrShimExited = errors.New("containerd: shim exited before container process was started")
 
 	errNoPidFile      = errors.New("containerd: no process pid file found")
 	errInvalidPidInt  = errors.New("containerd: process pid is invalid")

--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -62,9 +62,23 @@ func (w *worker) Start() {
 		}
 		if err := w.s.monitorProcess(process); err != nil {
 			logrus.WithField("error", err).Error("containerd: add process to monitor")
+			t.Err <- err
+			evt := &DeleteTask{
+				ID:      t.Container.ID(),
+				NoEvent: true,
+			}
+			w.s.SendTask(evt)
+			continue
 		}
 		if err := process.Start(); err != nil {
 			logrus.WithField("error", err).Error("containerd: start init process")
+			t.Err <- err
+			evt := &DeleteTask{
+				ID:      t.Container.ID(),
+				NoEvent: true,
+			}
+			w.s.SendTask(evt)
+			continue
 		}
 		ContainerStartTimer.UpdateSince(started)
 		t.Err <- nil


### PR DESCRIPTION
This fixes a sync issue when the containerd api returns after a
container has started.  It fixes it by calling the runtime start inside
containerd after the oom handler has been setup.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>