### PR TITLE
Fix controlPipe is not closed

### DIFF
--- a/runtime/process.go
+++ b/runtime/process.go
@@ -201,7 +201,11 @@ func (p *process) Stdio() Stdio {
 
 // Close closes any open files and/or resouces on the process
 func (p *process) Close() error {
-	return p.exitPipe.Close()
+	err := p.exitPipe.Close()
+	if cerr := p.controlPipe.Close(); err == nil {
+		err = cerr
+	}
+	return err
 }
 
 func (p *process) State() State {


### PR DESCRIPTION
Fix #275

It seems controlPipe.Close() is missing

Signed-off-by: Harry Zhang <harryzhang@zju.edu.cn>