### PR TITLE
Stop creating `/tmp/shim-delete-<pid>` as noone uses it

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -115,7 +114,6 @@ func start(log *os.File) error {
 			}
 			// runtime has exited so the shim can also exit
 			if exitShim {
-				ioutil.WriteFile(fmt.Sprintf("/tmp/shim-delete-%d", p.pid()), []byte("deleting"), 0600)
 				p.delete()
 				p.Wait()
 				return nil


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

This just end up polluting `/tmp` with hundreds of files otherwise