### PR TITLE
Handle case where shim is reaped before the call to the runtime start

### DIFF
--- a/integration-test/check_test.go
+++ b/integration-test/check_test.go
@@ -258,13 +258,13 @@ func (cs *ContainerdSuite) TearDownTest(c *check.C) {
 		})
 
 		if err := cs.KillContainer(ctr.Id); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to cleanup leftover test containers: %v", err)
+			fmt.Fprintf(os.Stderr, "Failed to cleanup leftover test containers: %v\n", err)
 		}
 
 		select {
 		case <-ch:
 		case <-time.After(3 * time.Second):
-			fmt.Fprintf(os.Stderr, "TearDownTest: Containerd %v didn't die after 3 seconds", ctr.Id)
+			fmt.Fprintf(os.Stderr, "TearDownTest: Containerd %v didn't die after 3 seconds\n", ctr.Id)
 		}
 	}
 }

--- a/supervisor/sort_test.go
+++ b/supervisor/sort_test.go
@@ -1,10 +1,10 @@
 package supervisor
 
 import (
+	"flag"
 	"os"
 	"sort"
 	"testing"
-	"flag"
 
 	"github.com/docker/containerd/runtime"
 	"github.com/docker/containerd/specs"
@@ -71,7 +71,6 @@ func (p *testProcess) State() runtime.State {
 }
 
 func (p *testProcess) Wait() {
-
 }
 
 func TestSortProcesses(t *testing.T) {


### PR DESCRIPTION
This avoid erroring out with a false positive

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>