### PR TITLE
Fix attach to old running container after restart

### DIFF
--- a/runtime/process.go
+++ b/runtime/process.go
@@ -132,6 +132,13 @@ func loadProcess(root, id string, c *container, s *ProcessState) (*process, erro
 				return nil, err
 			}
 			p.exitPipe = exit
+
+			control, err := getControlPipe(filepath.Join(root, ControlFile))
+			if err != nil {
+				return nil, err
+			}
+			p.controlPipe = control
+
 			return p, nil
 		}
 		return nil, err


### PR DESCRIPTION
Get the control pipe of old running container on
containerd restarting.

docker attach to a old running container will error out with
````
DEBU[0018] Calling POST /v1.25/containers/946a702de687/resize?h=38&w=199
ERRO[0018] Handler for POST /v1.25/containers/946a702de687/resize returned error: rpc error: code = 3 desc = invalid argument
DEBU[0018] Calling POST /v1.25/containers/946a702de687/resize?h=37&w=198
ERRO[0018] Handler for POST /v1.25/containers/946a702de687/resize returned error: rpc error: code = 3 desc = invalid argumen
````

Signed-off-by: Lei Jitang <leijitang@huawei.com>