### PR TITLE
supervisor: create: always apply runtime args if non-empty

### DIFF
--- a/supervisor/create.go
+++ b/supervisor/create.go
@@ -30,6 +30,8 @@ func (s *Supervisor) start(t *StartTask) error {
 	rtArgs := s.runtimeArgs
 	if t.Runtime != "" {
 		rt = t.Runtime
+	}
+	if len(t.RuntimeArgs) != 0 {
 		rtArgs = t.RuntimeArgs
 	}
 	container, err := runtime.New(runtime.ContainerOpts{


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/24424

@mlaventure @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>