### PR TITLE
Remove obsolete comment about reaper in containerd/main.go

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -128,8 +128,6 @@ func main() {
 }
 
 func daemon(context *cli.Context) error {
-	// setup a standard reaper so that we don't leave any zombies if we are still alive
-	// this is just good practice because we are spawning new processes
 	s := make(chan os.Signal, 2048)
 	signal.Notify(s, syscall.SIGTERM, syscall.SIGINT)
 	sv, err := supervisor.New(


### PR DESCRIPTION
Sigchld reaper has been removed from containerd procss in
847690583f6aa5583617317d12bff50ccbfef96a, so the comment
is not need any more.

Signed-off-by: Lei Jitang <leijitang@huawei.com>