### PR TITLE
Do not set subpreaper on exec processes

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -113,6 +113,9 @@ func start(log *os.File) error {
 				// Let containerd take care of calling the runtime delete
 				p.Close()
 				p.Wait()
+
+				p.cmd.Wait()
+				f.Close()
 				return nil
 			}
 		case msg := <-msgC:

--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -59,10 +59,6 @@ func start(log *os.File) error {
 	// or if runtime exits before we hit the handler
 	signals := make(chan os.Signal, 2048)
 	signal.Notify(signals)
-	// set the shim as the subreaper for all orphaned processes created by the container
-	if err := osutils.SetSubreaper(1); err != nil {
-		return err
-	}
 	// open the exit pipe
 	f, err := os.OpenFile("exit", syscall.O_WRONLY, 0)
 	if err != nil {
@@ -115,7 +111,7 @@ func start(log *os.File) error {
 			// runtime has exited so the shim can also exit
 			if exitShim {
 				// Let containerd take care of calling the runtime delete
-				f.Close()
+				p.Close()
 				p.Wait()
 				return nil
 			}

--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -111,11 +111,12 @@ func start(log *os.File) error {
 			// runtime has exited so the shim can also exit
 			if exitShim {
 				// Let containerd take care of calling the runtime delete
-				p.Close()
-				p.Wait()
-
-				p.cmd.Wait()
 				f.Close()
+				p.Close()
+
+				p.Wait()
+				p.cmd.Wait()
+				p.delete()
 				return nil
 			}
 		case msg := <-msgC:

--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -65,6 +65,7 @@ type process struct {
 	consolePath    string
 	state          *processState
 	runtime        string
+	cmd            *exec.Cmd
 }
 
 func newProcess(id, bundle, runtimeName string) (*process, error) {
@@ -184,6 +185,7 @@ func (p *process) create() error {
 	cmd.Stderr = p.stdio.stderr
 	// Call out to setPDeathSig to set SysProcAttr as elements are platform specific
 	cmd.SysProcAttr = setPDeathSig()
+	p.cmd = cmd
 
 	if err := cmd.Start(); err != nil {
 		if exErr, ok := err.(*exec.Error); ok {

--- a/supervisor/delete.go
+++ b/supervisor/delete.go
@@ -10,11 +10,12 @@ import (
 // DeleteTask holds needed parameters to remove a container
 type DeleteTask struct {
 	baseTask
-	ID      string
-	Status  int
-	PID     string
-	NoEvent bool
-	Process runtime.Process
+	ID        string
+	Status    int
+	PID       string
+	NoEvent   bool
+	Process   runtime.Process
+	Container runtime.Container
 }
 
 func (s *Supervisor) delete(t *DeleteTask) error {

--- a/supervisor/monitor_linux.go
+++ b/supervisor/monitor_linux.go
@@ -116,6 +116,7 @@ func (m *Monitor) start() {
 						logrus.WithField("error", err).Error("containerd: close process IO")
 					}
 					EpollFdCounter.Dec(1)
+					t.SetExited()
 					m.exits <- t
 				}
 			case runtime.OOM:

--- a/supervisor/sort_test.go
+++ b/supervisor/sort_test.go
@@ -66,6 +66,13 @@ func (p *testProcess) Close() error {
 	return nil
 }
 
+func (p *testProcess) WaitExit() {
+
+}
+
+func (p *testProcess) SetExited() {
+}
+
 func (p *testProcess) State() runtime.State {
 	return runtime.Running
 }


### PR DESCRIPTION
Because an exec'd process needs to be reparented to the pid 1 of the
container the subreaper will cause issues with this and cause the parent
to stay outside of the namespace.

This makes runc on exec long running but there is not a better way to do
with when we do not have the subreaper reparent.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>