### PR TITLE
Don't call runc start when restoring a checkpoint

### DIFF
--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -72,16 +72,20 @@ func (w *worker) Start() {
 			w.s.SendTask(evt)
 			continue
 		}
-		if err := process.Start(); err != nil {
-			logrus.WithField("error", err).Error("containerd: start init process")
-			t.Err <- err
-			evt := &DeleteTask{
-				ID:      t.Container.ID(),
-				NoEvent: true,
-				Process: process,
+		// only call process start if we aren't restoring from a checkpoint
+		// if we have restored from a checkpoint then the process is already started
+		if t.CheckpointPath == "" {
+			if err := process.Start(); err != nil {
+				logrus.WithField("error", err).Error("containerd: start init process")
+				t.Err <- err
+				evt := &DeleteTask{
+					ID:      t.Container.ID(),
+					NoEvent: true,
+					Process: process,
+				}
+				w.s.SendTask(evt)
+				continue
 			}
-			w.s.SendTask(evt)
-			continue
 		}
 		ContainerStartTimer.UpdateSince(started)
 		t.Err <- nil


### PR DESCRIPTION
Fixes: #286 

The create/start split left checkpoint/restore broken in that the create
side was calling runc restore, which fully restores the process to
operation, leaving a call to `runc start` as an error (process already
started). This patch skips process.Start as it is an unnecessary (and
wrong) step for a restored checkpoint.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>