### PR TITLE
Avoid panicing if `cmd.Start()` from `container.createCmd()` failed

### DIFF
--- a/runtime/process.go
+++ b/runtime/process.go
@@ -297,7 +297,9 @@ func (p *process) Start() error {
 			}
 		case <-p.cmdDoneCh:
 			if !p.cmdSuccess {
-				cmd.Process.Kill()
+				if cmd.Process != nil {
+					cmd.Process.Kill()
+				}
 				cmd.Wait()
 				return ErrShimExited
 			}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--

Required to fix docker/docker#25955