### PR TITLE
Add a Jenkinsfile to define CI in the repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,13 @@
+wrappedNode(label: "linux && x86_64") {
+  deleteDir()
+  checkout scm
+
+  stage "build image"
+  def img = docker.build("dockerbuildbot/containerd:${gitCommit()}")
+  try {
+    stage "run tests"
+    sh "docker run --privileged --rm --name '${env.BUILD_TAG}' ${img.id} make test"
+  } finally {
+    sh "docker rmi -f ${img.id} ||:"
+  }
+}


### PR DESCRIPTION
This defines the jenkins job configuration in code, in the repository.

Once merged and existing PRs are rebased on this change, the `containerd Master` and `containerd-PRs` jobs on jenkins.dockerproject.org can be disabled/deleted.

In the future we can also add improvements like recording test results, etc.