### PR TITLE
shim: Fix description of cwd and arguments given to the shim process

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -25,8 +25,11 @@ type controlMessage struct {
 // containerd-shim is a small shim that sits in front of a runtime implementation
 // that allows it to be repartented to init and handle reattach from the caller.
 //
-// the cwd of the shim should be the bundle for the container.  Arg1 should be the path
-// to the state directory where the shim can locate fifos and other information.
+// the cwd of the shim should be the path to the state directory where the shim
+// can locate fifos and other information.
+// Arg0: id of the container
+// Arg1: bundle path
+// Arg2: runtime binary
 func main() {
 	flag.Parse()
 	cwd, err := os.Getwd()


### PR DESCRIPTION
That comment didn't seem to match the reality and confused me a bit. The
shim takes 3 arguments and the cwd is the containerd state directory.

I'm guessing it's a left over from the containerd split.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>