### PR TITLE
Start runc in detached mode when restoring a checkpoint

### DIFF
--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -135,6 +135,7 @@ func (p *process) create() error {
 		)
 	} else if p.checkpoint != nil {
 		args = append(args, "restore",
+			"-d",
 			"--image-path", p.checkpointPath,
 			"--work-path", filepath.Join(p.checkpointPath, "criu.work", "restore-"+time.Now().Format(time.RFC3339)),
 		)


### PR DESCRIPTION
Without this the shim cannot detect the death of the init process.

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com

--

Fixes #310 