### PR TITLE
Handle exec clingy children

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -106,7 +106,7 @@ func start(log *os.File) error {
 		case s := <-signals:
 			switch s {
 			case syscall.SIGCHLD:
-				exits, _ := osutils.Reap()
+				exits, _ := osutils.Reap(false)
 				for _, e := range exits {
 					// check to see if runtime is one of the processes that has exited
 					if e.Pid == p.pid() {
@@ -117,6 +117,9 @@ func start(log *os.File) error {
 			}
 			// runtime has exited so the shim can also exit
 			if exitShim {
+				// Wait for all the childs this process may have created
+				// (only needed for exec, but it won't hurt when done on init)
+				osutils.Reap(true)
 				// Let containerd take care of calling the runtime delete
 				f.Close()
 				p.Wait()

--- a/containerd/main.go
+++ b/containerd/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/containerd/api/grpc/server"
 	"github.com/docker/containerd/api/grpc/types"
 	"github.com/docker/containerd/api/http/pprof"
-	"github.com/docker/containerd/osutils"
 	"github.com/docker/containerd/supervisor"
 	"github.com/docker/docker/pkg/listeners"
 	"github.com/rcrowley/go-metrics"
@@ -160,7 +159,6 @@ func main() {
 func daemon(context *cli.Context) error {
 	s := make(chan os.Signal, 2048)
 	signal.Notify(s, syscall.SIGTERM, syscall.SIGINT)
-	osutils.SetSubreaper(1)
 	sv, err := supervisor.New(
 		context.String("state-dir"),
 		context.String("runtime"),

--- a/osutils/reaper.go
+++ b/osutils/reaper.go
@@ -12,13 +12,17 @@ type Exit struct {
 
 // Reap reaps all child processes for the calling process and returns their
 // exit information
-func Reap() (exits []Exit, err error) {
+func Reap(wait bool) (exits []Exit, err error) {
 	var (
 		ws  syscall.WaitStatus
 		rus syscall.Rusage
 	)
+	flag := syscall.WNOHANG
+	if wait {
+		flag = 0
+	}
 	for {
-		pid, err := syscall.Wait4(-1, &ws, syscall.WNOHANG, &rus)
+		pid, err := syscall.Wait4(-1, &ws, flag, &rus)
 		if err != nil {
 			if err == syscall.ECHILD {
 				return exits, nil


### PR DESCRIPTION
This fixes a few things:
 - prevent `containerd` from ignoring requests in the case where an exec process spawned children that are keeping the IO open
 - correctly reap children of exec processes before exiting the shim to avoid zombies
 - ensure that we correctly wait for our children when we received a `SIGCHLD`. Before with `WNOHANG` it was possible for us to return without wait having actually done its job (it would return `0` as pid)

--

Addresses docker/docker#26403 and docker/docker#26506 