### PR TITLE
add a defer file close

### DIFF
--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -155,14 +155,13 @@ func (c *container) getMemoryEventFD(root string) (*oom, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	fd, _, serr := syscall.RawSyscall(syscall.SYS_EVENTFD2, 0, syscall.FD_CLOEXEC, 0)
 	if serr != 0 {
-		f.Close()
 		return nil, serr
 	}
 	if err := c.writeEventFD(root, int(f.Fd()), int(fd)); err != nil {
 		syscall.Close(int(fd))
-		f.Close()
 		return nil, err
 	}
 	return &oom{


### PR DESCRIPTION
In the original code there, when running into an error, in the block before return, close the file opened.

While I think when no error happens, containerd still needs to close it.
 
Signed-off-by: allencloud <allen.sun@daocloud.io>