### PR TITLE
remove field control from struct oom

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -680,7 +680,6 @@ func isAlive(cmd *exec.Cmd) (bool, error) {
 type oom struct {
 	id      string
 	root    string
-	control *os.File
 	eventfd int
 }
 
@@ -703,11 +702,7 @@ func (o *oom) Removed() bool {
 }
 
 func (o *oom) Close() error {
-	err := syscall.Close(o.eventfd)
-	if cerr := o.control.Close(); err == nil {
-		err = cerr
-	}
-	return err
+	return syscall.Close(o.eventfd)
 }
 
 type message struct {

--- a/runtime/container_linux.go
+++ b/runtime/container_linux.go
@@ -155,20 +155,18 @@ func (c *container) getMemoryEventFD(root string) (*oom, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	fd, _, serr := syscall.RawSyscall(syscall.SYS_EVENTFD2, 0, syscall.FD_CLOEXEC, 0)
 	if serr != 0 {
-		f.Close()
 		return nil, serr
 	}
 	if err := c.writeEventFD(root, int(f.Fd()), int(fd)); err != nil {
 		syscall.Close(int(fd))
-		f.Close()
 		return nil, err
 	}
 	return &oom{
 		root:    root,
 		id:      c.id,
 		eventfd: int(fd),
-		control: f,
 	}, nil
 }


### PR DESCRIPTION
remove field control from struct oom

As in `c.writeEventFD(root, int(f.Fd()), int(fd))`, it finishes to write f.FD() to event_control file, then f is not needed any more.
Then it is no need to add it to oom instance.
At last, I feel that field `control` is useless in struct `oom`.
 
Signed-off-by: allencloud <allen.sun@daocloud.io>