### PR TITLE
Do not have shim wait on grand children

### DIFF
--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -124,10 +124,6 @@ func start(log *os.File) error {
 				// children of the container have died if init was not
 				// started in its own PID namespace.
 				f.Close()
-				// Wait for all the childs this process may have
-				// created (needed for exec and init processes when
-				// they join another pid namespace)
-				osutils.Reap(true)
 				p.Wait()
 				return nil
 			}


### PR DESCRIPTION
This was added during the short time where containerd was being a
subreaper and as such is no longer necessary. On the contrary, it
prevents execs to correctly return if their children correctly detach
from their parent IOs.

2 tests were added to test both cases

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

--

ping @tonistiigi @crosbymichael 