### PR TITLE
Use golang.org/x/net/context for now

### DIFF
--- a/containerd-shim/process_linux.go
+++ b/containerd-shim/process_linux.go
@@ -3,12 +3,12 @@
 package main
 
 import (
-	"context"
 	"io"
 	"syscall"
 	"time"
 
 	"github.com/tonistiigi/fifo"
+	"golang.org/x/net/context"
 )
 
 // setPDeathSig sets the parent death signal to SIGKILL so that if the

--- a/vendor/src/github.com/tonistiigi/fifo/fifo.go
+++ b/vendor/src/github.com/tonistiigi/fifo/fifo.go
@@ -1,7 +1,6 @@
 package fifo
 
 import (
-	"context"
 	"io"
 	"os"
 	"runtime"
@@ -9,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 type fifo struct {


### PR DESCRIPTION
We'll move to "context" once the grpc, protobuf and protoc-gen-go packages have
done so (see https://github.com/grpc/grpc-go/issues/711)

This also forced me to manually update tonistiigi/fifo to use the old
context path for now.

This change ensures we stay compatible with go1.6.x

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>