### PR TITLE
Sync exit events

### DIFF
--- a/supervisor/add_process.go
+++ b/supervisor/add_process.go
@@ -36,6 +36,7 @@ func (s *Supervisor) addProcess(t *AddProcessTask) error {
 		return err
 	}
 	ExecProcessTimer.UpdateSince(start)
+	s.newExecSyncChannel(t.ID, t.PID)
 	t.StartResponse <- StartResponse{ExecPid: process.SystemPid()}
 	s.notifySubscribers(Event{
 		Timestamp: time.Now(),

--- a/supervisor/sort.go
+++ b/supervisor/sort.go
@@ -23,5 +23,5 @@ func (s *processSorter) Swap(i, j int) {
 }
 
 func (s *processSorter) Less(i, j int) bool {
-	return s.processes[j].ID() == "init"
+	return s.processes[j].ID() == runtime.InitProcessID
 }

--- a/supervisor/worker.go
+++ b/supervisor/worker.go
@@ -90,6 +90,7 @@ func (w *worker) Start() {
 			}
 		}
 		ContainerStartTimer.UpdateSince(started)
+		w.s.newExecSyncMap(t.Container.ID())
 		t.Err <- nil
 		t.StartResponse <- StartResponse{
 			Container: t.Container,


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Addresses https://github.com/docker/docker/issues/27626

Note: initially I had used:
```
type execSync struct {
	pid string
	ch  chan struct{}.
}

// Supervisor represents a container supervisor
type Supervisor struct {
        [...]
	// This is used to ensure that exec process death events are sent
	// before the init process death
	containerExecSync map[string]execSync{}
}
```

But I decided to accommodate for container holding a lot of execs. The current version is uglier though, I can change the implementation to use the above type instead if it hurts eyes too much.
