### PR TITLE
api: fix pprof-address usage

### DIFF
--- a/api/http/pprof/pprof.go
+++ b/api/http/pprof/pprof.go
@@ -4,7 +4,8 @@ import (
 	// expvar init routine adds the "/debug/vars" handler
 	_ "expvar"
 	"net/http"
-	"net/http/pprof"
+	// net/http/pprof installs the "/debug/pprof/{block,heap,goroutine,threadcreate}" handler
+	_ "net/http/pprof"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -12,11 +13,6 @@ import (
 // Enable registers the "/debug/pprof" handler
 func Enable(address string) {
 	http.Handle("/", http.RedirectHandler("/debug/pprof", http.StatusMovedPermanently))
-
-	http.Handle("/debug/pprof/block", pprof.Handler("block"))
-	http.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-	http.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-	http.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
 
 	go http.ListenAndServe(address, nil)
 	logrus.Debug("pprof listening in address %s", address)


### PR DESCRIPTION
Adding the following line will install handlers under the `/debug/pprof/` URL to download live profiles:

```
import _ "net/http/pprof"
```

see: https://golang.org/pkg/net/http/pprof/ and https://golang.org/pkg/runtime/pprof/

Signed-off-by: Wang Long <long.wanglong@huawei.com>