### PR TITLE
Use runc kill all for process termination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN set -x \
 	&& rm -rf "$SECCOMP_PATH"
 
 # Install runc
-ENV RUNC_COMMIT ac031b5bf1cc92239461125f4c1ffb760522bbf2
+ENV RUNC_COMMIT 51371867a01c467f08af739783b8beafc154c4d7
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
     && git clone git://github.com/docker/runc.git "$GOPATH/src/github.com/opencontainers/runc" \

--- a/containerd-shim/main.go
+++ b/containerd-shim/main.go
@@ -121,14 +121,14 @@ func start(log *os.File) error {
 			}
 			// runtime has exited so the shim can also exit
 			if exitShim {
-				// Let containerd take care of calling the runtime
-				// delete.
-				// This is needed to be done first in order to ensure
-				// that the call to Reap does not block until all
-				// children of the container have died if init was not
-				// started in its own PID namespace.
-				f.Close()
+				// kill all processes in the container incase it was not running in
+				// its own PID namespace
+				p.killAll()
+				// wait for all the processes and IO to finish
 				p.Wait()
+				// delete the container from the runtime
+				p.delete()
+				// the close of the exit fifo will happen when the shim exits
 				return nil
 			}
 		case msg := <-msgC:

--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -217,18 +217,6 @@ func (p *process) pid() int {
 	return p.containerPid
 }
 
-func (p *process) killAll() error {
-	if !p.state.Exec {
-		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "kill", "--all", p.id, "SIGKILL")...)
-		cmd.SysProcAttr = setPDeathSig()
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("%s: %v", out, err)
-		}
-	}
-	return nil
-}
-
 func (p *process) delete() error {
 	if !p.state.Exec {
 		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "delete", p.id)...)

--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -217,6 +217,18 @@ func (p *process) pid() int {
 	return p.containerPid
 }
 
+func (p *process) killAll() error {
+	if !p.state.Exec {
+		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "kill", "--all", p.id, "SIGKILL")...)
+		cmd.SysProcAttr = setPDeathSig()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s: %v", out, err)
+		}
+	}
+	return nil
+}
+
 func (p *process) delete() error {
 	if !p.state.Exec {
 		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "delete", p.id)...)

--- a/containerd-shim/process_linux.go
+++ b/containerd-shim/process_linux.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os/exec"
 	"syscall"
 	"time"
 
@@ -114,5 +115,17 @@ func (p *process) openIO() error {
 		f.Close()
 	}()
 
+	return nil
+}
+
+func (p *process) killAll() error {
+	if !p.state.Exec {
+		cmd := exec.Command(p.runtime, append(p.state.RuntimeArgs, "kill", "--all", p.id, "SIGKILL")...)
+		cmd.SysProcAttr = setPDeathSig()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s: %v", out, err)
+		}
+	}
 	return nil
 }

--- a/containerd-shim/process_solaris.go
+++ b/containerd-shim/process_solaris.go
@@ -64,3 +64,7 @@ func (p *process) openIO() error {
 
 	return nil
 }
+
+func (p *process) killAll() error {
+	return nil
+}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -14,7 +14,7 @@ clone git github.com/docker/go-units 5d2041e26a699eaca682e2ea41c8f891e1060444
 clone git github.com/godbus/dbus e2cf28118e66a6a63db46cf6088a35d2054d3bb0
 clone git github.com/golang/glog 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 clone git github.com/golang/protobuf 1f49d83d9aa00e6ce4fc8258c71cc7786aec968a
-clone git github.com/opencontainers/runc ac031b5bf1cc92239461125f4c1ffb760522bbf2 https://github.com/docker/runc.git
+clone git github.com/opencontainers/runc 51371867a01c467f08af739783b8beafc154c4d7 https://github.com/docker/runc.git
 clone git github.com/opencontainers/runtime-spec 1c7c27d043c2a5e513a44084d2b10d77d1402b8c
 clone git github.com/rcrowley/go-metrics eeba7bd0dd01ace6e690fa833b3f22aaec29af43
 clone git github.com/satori/go.uuid f9ab0dce87d815821e221626b772e3475a0d2749

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -250,12 +250,9 @@ func (c *container) readSpec() (*specs.Spec, error) {
 
 func (c *container) Delete() error {
 	var err error
-	args := c.runtimeArgs
-	args = append(args, "delete", c.id)
+	args := append(c.runtimeArgs, "delete", c.id)
 	if b, derr := exec.Command(c.runtime, args...).CombinedOutput(); err != nil {
 		err = fmt.Errorf("%s: %q", derr, string(b))
-	} else if len(b) > 0 {
-		logrus.Debugf("%v %v: %q", c.runtime, args, string(b))
 	}
 	if rerr := os.RemoveAll(filepath.Join(c.root, c.id)); rerr != nil {
 		if err != nil {


### PR DESCRIPTION
Before this change we would rely on containerd to call delete that also
had logic to kill all processes in a container via cgroups for
containers that run in another pid namespace.  This changes allows us to
decouple the kil all logic and delete so that we don't have to have
containerd calling delete and it can all be handled in the shim again.
This will hopefully prevent races where higher level logic was trying to
remove a containers fs before the shim actually exits.  Now the exit
fifo will not be closed until the shim actually exits.

This should hopefully resolve https://github.com/docker/docker/issues/27381

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>