### PR TITLE
Fix the error check in Delete method

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -251,7 +251,7 @@ func (c *container) readSpec() (*specs.Spec, error) {
 func (c *container) Delete() error {
 	var err error
 	args := append(c.runtimeArgs, "delete", c.id)
-	if b, derr := exec.Command(c.runtime, args...).CombinedOutput(); err != nil {
+	if b, derr := exec.Command(c.runtime, args...).CombinedOutput(); derr != nil {
 		err = fmt.Errorf("%s: %q", derr, string(b))
 	}
 	if rerr := os.RemoveAll(filepath.Join(c.root, c.id)); rerr != nil {


### PR DESCRIPTION
Rebase of #344

Closes #344

we should check the `derr` at here, not the `err`.

Signed-off-by: Wang Long <long.wanglong@huawei.com>
Signed-off-by: Michael Crosby <crosbymichael@gmail.com>