### PR TITLE
Makefile: supply TARGET to install to specified target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2> /dev/null)
 
 LDFLAGS := -X github.com/docker/containerd.GitCommit=${GIT_COMMIT} ${LDFLAGS}
 
+TARGET ?= /usr/local/bin
+
 TEST_TIMEOUT ?= 5m
 TEST_SUITE_TIMEOUT ?= 10m
 
@@ -73,7 +75,7 @@ dbench: dbuild
 	$(DOCKER_RUN) make bench
 
 install:
-	cp bin/* /usr/local/bin/
+	cp bin/* $(TARGET)
 
 protoc:
 	protoc -I ./api/grpc/types ./api/grpc/types/api.proto --go_out=plugins=grpc:api/grpc/types


### PR DESCRIPTION
This is similar to PREFIX from configure but I couldn't see a good reason for PREFIX literally. I'd like to embed an installation of containerd with a small tool of mine (and in a less global place than /usr/local/bin) so this would make it a little easier.