### PR TITLE
Fix compilation error in events/events_test.go

### DIFF
--- a/events/events_test.go
+++ b/events/events_test.go
@@ -12,19 +12,19 @@ func TestBasicEvent(t *testing.T) {
 	// simulate a layer pull with events
 	ctx, commit, _ := WithTx(ctx)
 
-	G(ctx).Post("pull ubuntu")
+	G(ctx).Post(ctx, "pull ubuntu")
 
 	for layer := 0; layer < 4; layer++ {
 		// make a subtransaction for each layer
 		ctx, commit, _ := WithTx(ctx)
 
-		G(ctx).Post(fmt.Sprintf("fetch layer %v", layer))
+		G(ctx).Post(ctx, fmt.Sprintf("fetch layer %v", layer))
 
 		ctx = WithTopic(ctx, "content")
 		// simulate sub-operations with a separate topic, on the content store
-		G(ctx).Post(fmt.Sprintf("received sha:256"))
+		G(ctx).Post(ctx, fmt.Sprintf("received sha:256"))
 
-		G(ctx).Post(fmt.Sprintf("unpack layer %v", layer))
+		G(ctx).Post(ctx, fmt.Sprintf("unpack layer %v", layer))
 
 		commit()
 	}


### PR DESCRIPTION
Compilation was failing

```
# github.com/docker/containerd/events
events/events_test.go:25: ctx.fmt undefined (type context.Context has no field or method fmt)
events/events_test.go:25: not enough arguments in ca
```

The test passes now, but maybe I'd better fix events.go rather than events_test.go?

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>