### PR TITLE
execution/oci: validate bundle path

### DIFF
--- a/execution/executors/oci/oci.go
+++ b/execution/executors/oci/oci.go
@@ -37,6 +37,9 @@ type OCIRuntime struct {
 }
 
 func (r *OCIRuntime) Create(ctx context.Context, id string, o execution.CreateOpts) (container *execution.Container, err error) {
+	if o.Bundle == "" {
+		return nil, errors.New("bundle path cannot be an empty string")
+	}
 	oio, err := newOIO(o.Stdin, o.Stdout, o.Stderr, o.Console)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Sending the empty string either via `ctr` or via grpc results in `runc` trying to run a container from `pwd` (or something like this.
This results into a suble error:
```sh
$ sudo ./bin/ctr --debug run test
JSON specification file config.json not found
rpc error: code = 2 desc = exit status 1
```
Instead:
```sh
$ sudo ./bin/ctr --debug run test
rpc error: code = 2 desc = bundle path cannot be an empty string
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>