### PR TITLE
delete state directory after unclean exits

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -331,7 +331,7 @@ func (s *Supervisor) restore() error {
 		id := d.Name()
 		container, err := runtime.Load(s.stateDir, id, s.shim, s.timeout)
 		if err != nil {
-			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state diretory.")
+			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state directory.")
 			os.RemoveAll(filepath.Join(s.stateDir, id))
 			continue
 		}

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -331,7 +331,9 @@ func (s *Supervisor) restore() error {
 		id := d.Name()
 		container, err := runtime.Load(s.stateDir, id, s.shim, s.timeout)
 		if err != nil {
-			return err
+			logrus.WithFields(logrus.Fields{"error": err, "id": id}).Warnf("containerd: failed to load container,removing state diretory.")
+			os.RemoveAll(filepath.Join(s.stateDir, id))
+			continue
 		}
 		processes, err := container.Processes()
 		if err != nil {


### PR DESCRIPTION
fixed https://github.com/docker/docker/issues/29748 ，
As it's an unclean exit, we should remove state directory and go on ,an container may show exited state ,but anyhow we could restart the containerd process and the containers later.