### PR TITLE
fix ineffassign: use processes array

### DIFF
--- a/execution/service.go
+++ b/execution/service.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, executor Executor) (*Service, error) {
 			// generate exit event for all processes, (generate event for init last)
 			processes := c.Processes()
 			processes = append(processes[1:], processes[0])
-			for _, p := range c.Processes() {
+			for _, p := range processes {
 				if p.Status() != Stopped {
 					p.Signal(os.Kill)
 				}


### PR DESCRIPTION
uses processes variable instead of calling the Processes() func again

However the code itself is a bit weird though as `c.processes` is a map, so iterate over it doesn't guarantee order, therefore init may not be the first return process. if we want to guarantee that, we need to always put initPid into first place in the array. Did I understand this correctly ?