### PR TITLE
Put coverage files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+*/coverage.txt


### PR DESCRIPTION
```
23:59 $ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
(use "git add <file>..." to include in what will be committed)

    events/coverage.txt
    gc/coverage.txt
    log/coverage.txt
    snapshot/coverage.txt

```

I run `make coverage` and I just noticed that all generated files are
not in gitignore.

Signed-off-by: Gianluca Arbezzano <ga@thumpflow.com>