### PR TITLE
Makefile: allow `make install` without `go`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,10 @@ clean: ## clean up binaries
 	@echo "🐳 $@"
 	@rm -f $(BINARIES)
 
-install: $(BINARIES) ## install binaries
-	@echo "🐳 $@"
+install: ## install binaries
+	@ls $(BINARIES) > /dev/null 2>&1 || \
+		(echo "👹 Please run \`make\` before running \`make install\`." && false)
+	@echo "🐳 $@ $(BINARIES)"
 	@mkdir -p $(DESTDIR)/bin
 	@install $(BINARIES) $(DESTDIR)/bin
 


### PR DESCRIPTION
In my environment, `sudo make install` fails, because Go is installed under my home directory.

```console
suda@ws01:~/gopath/src/github.com/docker/containerd> which go
/home/suda/.gvm/gos/go1.7/bin/go
suda@ws01:~/gopath/src/github.com/docker/containerd> make
🐳 bin/ctr
🐳 bin/containerd
🐳 bin/containerd-shim
🐳 bin/protoc-gen-gogoctrd
🐳 binaries
suda@ws01:~/gopath/src/github.com/docker/containerd> sudo make install
/bin/sh: 1: go: not found
/bin/sh: 1: test: =: unexpected operator
👹 Please correctly set up your Go build environment. This project must be located at <GOPATH>/src/github.com/docker/containerd
Makefile:99: recipe for target 'bin/ctr' failed
make: *** [bin/ctr] Error 1
```

So I suggest allowing `make install` without requiring Go.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>