### PR TITLE
test: allow running tests as non-root

### DIFF
--- a/snapshot/btrfs_test.go
+++ b/snapshot/btrfs_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/docker/containerd"
+	"github.com/docker/containerd/testutil"
 	btrfs "github.com/stevvooe/go-btrfs"
 )
 
@@ -18,6 +19,7 @@ const (
 )
 
 func TestBtrfs(t *testing.T) {
+	testutil.Requires(t, testutil.Privileged)
 	device := setupBtrfsLoopbackDevice(t)
 	defer removeBtrfsLoopbackDevice(t, device)
 	root, err := ioutil.TempDir(device.mountPoint, "TestBtrfsPrepare-")

--- a/snapshot/manager_test.go
+++ b/snapshot/manager_test.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 
 	"github.com/docker/containerd"
+	"github.com/docker/containerd/testutil"
 )
 
 // TestSnapshotManagerBasic implements something similar to the conceptual
 // examples we've discussed thus far. It does perform mounts, so you must run
 // as root.
 func TestSnapshotManagerBasic(t *testing.T) {
+	testutil.Requires(t, testutil.Privileged)
 	tmpDir, err := ioutil.TempDir("", "test-layman-")
 	if err != nil {
 		t.Fatal(err)

--- a/snapshot/naive_test.go
+++ b/snapshot/naive_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	"github.com/docker/containerd"
+	"github.com/docker/containerd/testutil"
 )
 
 func TestSnapshotNaiveBasic(t *testing.T) {
+	testutil.Requires(t, testutil.Privileged)
 	tmpDir, err := ioutil.TempDir("", "test-layman-")
 	if err != nil {
 		t.Fatal(err)

--- a/snapshot/overlayfs_test.go
+++ b/snapshot/overlayfs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/containerd"
+	"github.com/docker/containerd/testutil"
 )
 
 func TestOverlayfs(t *testing.T) {
@@ -126,9 +127,7 @@ func TestOverlayfsOverlayMount(t *testing.T) {
 }
 
 func TestOverlayfsOverlayRead(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("not running as root")
-	}
+	testutil.Requires(t, testutil.Privileged)
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,34 @@
+// Package testutil is a package only used for testing
+package testutil
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+// Requirement is a requirement for executing the test
+type Requirement func() bool
+
+// Requires skips the test if requirement is not satisfied
+func Requires(t *testing.T, requirements ...Requirement) {
+	for _, r := range requirements {
+		if !r() {
+			s := runtime.FuncForPC(reflect.ValueOf(r).Pointer()).Name()
+			t.Skipf("unmatched requirement %s", s)
+		}
+	}
+}
+
+// Privileged is a requirement that requires a privileged user (i.e. root).
+func Privileged() bool {
+	// NOTE: we could use os/user.Current() for implementing this function.
+	// However, we hesitate to call os/user.Current() due to a glibc issue
+	// that leads to SEGV when the glibc is statically linked with,
+	// although it is unlikely statically linked for test binaries.
+	// https://github.com/docker/docker/pull/29478
+
+	// TODO: support Windows
+	return os.Getuid() == 0
+}


### PR DESCRIPTION
Some tests were failing if the user is non-root

```console
$ make test
🐳 test
?       github.com/docker/containerd    [no test files]
?       github.com/docker/containerd/api/execution      [no test files]
?       github.com/docker/containerd/bundle     [no test files]
?       github.com/docker/containerd/cmd/containerd     [no test files]
?       github.com/docker/containerd/cmd/containerd-shim        [no test files]
?       github.com/docker/containerd/cmd/ctr    [no test files]
?       github.com/docker/containerd/cmd/protoc-gen-gogoctrd    [no test files]
ok      github.com/docker/containerd/content    13.381s
ok      github.com/docker/containerd/events     1.014s
?       github.com/docker/containerd/execution  [no test files]
?       github.com/docker/containerd/execution/executors/oci    [no test files]
?       github.com/docker/containerd/execution/executors/shim   [no test files]
ok      github.com/docker/containerd/gc 1.011s
ok      github.com/docker/containerd/log        1.015s
--- FAIL: TestBtrfs (0.22s)
        btrfs_test.go:126: Temporary mount point created /tmp/containerd-btrfs-test805144255
        btrfs_test.go:133: Temporary file created /tmp/containerd-btrfs-test634750738
        btrfs_test.go:152: losetup: /tmp/containerd-btrfs-test634750738: failed to set up loop device: Permission denied

        btrfs_test.go:153: Could not run losetup exit status 1
mount: only root can use "--options" option
--- FAIL: TestSnapshotManagerBasic (0.00s)
        manager_test.go:55: [mount -t overlay none /tmp/test-layman-034759497/preparing -o upperdir=/tmp/test-layman-034759497/root/diff-769738260,workdir=/tmp/test-layman-034759497/root/work-091225699,lowerdir=/tmp/test-layman-034759497/root/empty]
        manager_test.go:59: exit status 1
        manager_test.go:22: Removing /tmp/test-layman-034759497
--- FAIL: TestSnapshotNaiveBasic (0.00s)
        naive_test.go:20: /tmp/test-layman-196749414
        naive_test.go:61: copying of parent failed: chown /tmp/test-layman-196749414/root/active-823990413/data: operation not permitted
FAIL
FAIL    github.com/docker/containerd/snapshot   0.241s
?       github.com/docker/containerd/specification      [no test files]
?       github.com/docker/containerd/sys        [no test files]
Makefile:88: recipe for target 'test' failed
make: *** [test] Error 1
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>