### PR TITLE
ctr: add commands: `list` and `inspect`

### DIFF
--- a/cmd/ctr/inspect.go
+++ b/cmd/ctr/inspect.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	gocontext "context"
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/docker/containerd/api/execution"
+	"github.com/urfave/cli"
+)
+
+var inspectCommand = cli.Command{
+	Name:  "inspect",
+	Usage: "inspect a container",
+	Action: func(context *cli.Context) error {
+		executionService, err := getExecutionService(context)
+		if err != nil {
+			return err
+		}
+		id := context.Args().First()
+		if id == "" {
+			return fmt.Errorf("container id must be provided")
+		}
+		getResponse, err := executionService.Get(gocontext.Background(),
+			&execution.GetContainerRequest{ID: id})
+		if err != nil {
+			return err
+		}
+		listProcResponse, err := executionService.ListProcesses(gocontext.Background(),
+			&execution.ListProcessesRequest{ID: id})
+		if err != nil {
+			return err
+		}
+		dumper := spew.NewDefaultConfig()
+		dumper.Indent = "\t"
+		dumper.DisableMethods = true
+		dumper.DisablePointerAddresses = true
+		dumper.Dump(getResponse, listProcResponse)
+		return nil
+	},
+}

--- a/cmd/ctr/list.go
+++ b/cmd/ctr/list.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	gocontext "context"
+	"fmt"
+
+	"github.com/docker/containerd/api/execution"
+	"github.com/urfave/cli"
+)
+
+var listCommand = cli.Command{
+	Name:  "list",
+	Usage: "list containers",
+	Action: func(context *cli.Context) error {
+		executionService, err := getExecutionService(context)
+		if err != nil {
+			return err
+		}
+		listResponse, err := executionService.List(gocontext.Background(), &execution.ListContainersRequest{
+			Owner: []string{},
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("ID\tSTATUS\tPROCS\tBUNDLE\n")
+		for _, c := range listResponse.Containers {
+			listProcResponse, err := executionService.ListProcesses(gocontext.Background(),
+				&execution.ListProcessesRequest{ID: c.ID})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s\t%s\t%d\t%s\n",
+				c.ID,
+				c.Status,
+				len(listProcResponse.Processes),
+				c.BundlePath,
+			)
+		}
+		return nil
+	},
+}

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -38,6 +38,8 @@ containerd client
 		execCommand,
 		eventsCommand,
 		deleteCommand,
+		listCommand,
+		inspectCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/vendor.conf
+++ b/vendor.conf
@@ -43,7 +43,7 @@ github.com/Sirupsen/logrus v0.11.0
 github.com/stevvooe/go-btrfs 029908fedf190147f3f673b0db7c836f83a6a6be
 # testify go testing support; latest release as of 12/16/2016
 github.com/stretchr/testify v1.1.4
-# go-spew (required by testify); latest release as of 1/12/2017
+# go-spew (required by testify, and also by ctr); latest release as of 1/12/2017
 github.com/davecgh/go-spew v1.1.0
 # go-difflib (required by testify); latest release as of 1/12/2017
 github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
Example

```console
$ sudo ctr list
ID      STATUS  PROCS   BUNDLE
foo     RUNNING 1       /home/suda/tmp/ocibundle/busybox
```

```console
$ sudo ctr inspect foo
(*execution.GetContainerResponse)({
        Container: (*execution.Container)({
                ID: (string) (len=3) "foo",
                BundlePath: (string) (len=32) "/home/suda/tmp/ocibundle/busybox",
                Status: (execution.Status) 1
        })
})
(*execution.ListProcessesResponse)({
        Processes: ([]*execution.Process) (len=1 cap=1) {
                (*execution.Process)({
                        ID: (string) (len=4) "init",
                        Pid: (int64) 11922,
                        Args: ([]string) <nil>,
                        Env: ([]string) <nil>,
                        User: (*execution.User)(<nil>),
                        Cwd: (string) "",
                        Terminal: (bool) false,
                        ExitStatus: (uint32) 0
                })
        }
})
```

The output is not pretty, but I think it is enough as a dev tool.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>