### PR TITLE
snapshot: fix terminology inconsistency

### DIFF
--- a/snapshot/btrfs/btrfs.go
+++ b/snapshot/btrfs/btrfs.go
@@ -19,8 +19,8 @@ func NewBtrfs(device, root string) (*Btrfs, error) {
 	return &Btrfs{device: device, root: root}, nil
 }
 
-func (lm *Btrfs) Prepare(key, parent string) ([]containerd.Mount, error) {
-	active := filepath.Join(lm.root, "active")
+func (b *Btrfs) Prepare(key, parent string) ([]containerd.Mount, error) {
+	active := filepath.Join(b.root, "active")
 	if err := os.MkdirAll(active, 0755); err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (lm *Btrfs) Prepare(key, parent string) ([]containerd.Mount, error) {
 	return []containerd.Mount{
 		{
 			Type:   "btrfs",
-			Source: lm.device, // device?
+			Source: b.device, // device?
 			// NOTE(stevvooe): While it would be nice to use to uuids for
 			// mounts, they don't work reliably if the uuids are missing.
 			Options: []string{fmt.Sprintf("subvolid=%d", info.ID)},
@@ -57,8 +57,8 @@ func (lm *Btrfs) Prepare(key, parent string) ([]containerd.Mount, error) {
 	}, nil
 }
 
-func (lm *Btrfs) Commit(name, key string) error {
-	dir := filepath.Join(lm.root, "active", hash(key))
+func (b *Btrfs) Commit(name, key string) error {
+	dir := filepath.Join(b.root, "active", hash(key))
 
 	fmt.Println("commit to", name)
 	if err := btrfs.SubvolSnapshot(name, dir, true); err != nil {

--- a/snapshot/btrfs/btrfs_test.go
+++ b/snapshot/btrfs/btrfs_test.go
@@ -28,11 +28,11 @@ func TestBtrfs(t *testing.T) {
 	defer os.RemoveAll(root)
 
 	target := filepath.Join(root, "test")
-	sm, err := NewBtrfs(device.deviceName, root)
+	b, err := NewBtrfs(device.deviceName, root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mounts, err := sm.Prepare(target, "")
+	mounts, err := b.Prepare(target, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestBtrfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := sm.Commit(filepath.Join(root, "snapshots/committed"), filepath.Join(root, "test")); err != nil {
+	if err := b.Commit(filepath.Join(root, "snapshots/committed"), filepath.Join(root, "test")); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
@@ -80,7 +80,7 @@ func TestBtrfs(t *testing.T) {
 	}()
 
 	target = filepath.Join(root, "test2")
-	mounts, err = sm.Prepare(target, filepath.Join(root, "snapshots/committed"))
+	mounts, err = b.Prepare(target, filepath.Join(root, "snapshots/committed"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestBtrfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := sm.Commit(filepath.Join(root, "snapshots/committed2"), target); err != nil {
+	if err := b.Commit(filepath.Join(root, "snapshots/committed2"), target); err != nil {
 		t.Fatal(err)
 	}
 	defer func() {

--- a/snapshot/manager_test.go
+++ b/snapshot/manager_test.go
@@ -14,7 +14,7 @@ import (
 // examples we've discussed thus far. It does perform mounts, so you must run
 // as root.
 func TestSnapshotManagerBasic(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test-layman-")
+	tmpDir, err := ioutil.TempDir("", "test-sm-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestSnapshotManagerBasic(t *testing.T) {
 
 	root := filepath.Join(tmpDir, "root")
 
-	lm, err := NewManager(root)
+	sm, err := NewManager(root)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestSnapshotManagerBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mounts, err := lm.Prepare(preparing, "")
+	mounts, err := sm.Prepare(preparing, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,14 +58,14 @@ func TestSnapshotManagerBasic(t *testing.T) {
 
 	os.MkdirAll(preparing+"/a/b/c", 0755)
 
-	committed := filepath.Join(lm.root, "committed")
+	committed := filepath.Join(sm.root, "committed")
 
-	if err := lm.Commit(committed, preparing); err != nil {
+	if err := sm.Commit(committed, preparing); err != nil {
 		t.Fatal(err)
 	}
 
-	if lm.Parent(preparing) != "" {
-		t.Fatalf("parent of new layer should be empty, got lm.Parent(%q) == %q", preparing, lm.Parent(preparing))
+	if sm.Parent(preparing) != "" {
+		t.Fatalf("parent of new layer should be empty, got sm.Parent(%q) == %q", preparing, sm.Parent(preparing))
 	}
 
 	next := filepath.Join(tmpDir, "nextlayer")
@@ -73,7 +73,7 @@ func TestSnapshotManagerBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mounts, err = lm.Prepare(next, committed)
+	mounts, err = sm.Prepare(next, committed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,12 +92,12 @@ func TestSnapshotManagerBasic(t *testing.T) {
 	}
 
 	os.RemoveAll(next + "/a/b")
-	nextCommitted := filepath.Join(lm.root, "committed-next")
-	if err := lm.Commit(nextCommitted, next); err != nil {
+	nextCommitted := filepath.Join(sm.root, "committed-next")
+	if err := sm.Commit(nextCommitted, next); err != nil {
 		t.Fatal(err)
 	}
 
-	if lm.Parent(nextCommitted) != committed {
-		t.Fatalf("parent of new layer should be %q, got lm.Parent(%q) == %q (%#v)", committed, next, lm.Parent(next), lm.parents)
+	if sm.Parent(nextCommitted) != committed {
+		t.Fatalf("parent of new layer should be %q, got sm.Parent(%q) == %q (%#v)", committed, next, sm.Parent(next), sm.parents)
 	}
 }

--- a/snapshot/naive/naive_test.go
+++ b/snapshot/naive/naive_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSnapshotNaiveBasic(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "test-layman-")
+	tmpDir, err := ioutil.TempDir("", "test-naive-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -19,7 +19,7 @@ func TestSnapshotNaiveBasic(t *testing.T) {
 	t.Log(tmpDir)
 	root := filepath.Join(tmpDir, "root")
 
-	lm, err := NewNaive(root)
+	n, err := NewNaive(root)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestSnapshotNaiveBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mounts, err := lm.Prepare(preparing, "")
+	mounts, err := n.Prepare(preparing, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,14 +46,14 @@ func TestSnapshotNaiveBasic(t *testing.T) {
 
 	// defer os.Remove(filepath.Join(tmpDir, "foo"))
 
-	committed := filepath.Join(lm.root, "committed")
+	committed := filepath.Join(n.root, "committed")
 
-	if err := lm.Commit(committed, preparing); err != nil {
+	if err := n.Commit(committed, preparing); err != nil {
 		t.Fatal(err)
 	}
 
-	if lm.Parent(preparing) != "" {
-		t.Fatalf("parent of new layer should be empty, got lm.Parent(%q) == %q", preparing, lm.Parent(preparing))
+	if n.Parent(preparing) != "" {
+		t.Fatalf("parent of new layer should be empty, got n.Parent(%q) == %q", preparing, n.Parent(preparing))
 	}
 
 	next := filepath.Join(tmpDir, "nextlayer")
@@ -61,7 +61,7 @@ func TestSnapshotNaiveBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mounts, err = lm.Prepare(next, committed)
+	mounts, err = n.Prepare(next, committed)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,12 +79,12 @@ func TestSnapshotNaiveBasic(t *testing.T) {
 	}
 
 	os.RemoveAll(next + "/a/b")
-	nextCommitted := filepath.Join(lm.root, "committed-next")
-	if err := lm.Commit(nextCommitted, next); err != nil {
+	nextCommitted := filepath.Join(n.root, "committed-next")
+	if err := n.Commit(nextCommitted, next); err != nil {
 		t.Fatal(err)
 	}
 
-	if lm.Parent(nextCommitted) != committed {
-		t.Fatalf("parent of new layer should be %q, got lm.Parent(%q) == %q (%#v)", committed, next, lm.Parent(next), lm.parents)
+	if n.Parent(nextCommitted) != committed {
+		t.Fatalf("parent of new layer should be %q, got n.Parent(%q) == %q (%#v)", committed, next, n.Parent(next), n.parents)
 	}
 }

--- a/snapshot/overlay/overlay.go
+++ b/snapshot/overlay/overlay.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/containerd"
 )
 
-func NewOverlayfs(root string) (*Overlayfs, error) {
+func NewOverlay(root string) (*Overlay, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
@@ -24,18 +24,18 @@ func NewOverlayfs(root string) (*Overlayfs, error) {
 			return nil, err
 		}
 	}
-	return &Overlayfs{
+	return &Overlay{
 		root:  root,
 		cache: newCache(),
 	}, nil
 }
 
-type Overlayfs struct {
+type Overlay struct {
 	root  string
 	cache *cache
 }
 
-func (o *Overlayfs) Prepare(key string, parentName string) ([]containerd.Mount, error) {
+func (o *Overlay) Prepare(key string, parentName string) ([]containerd.Mount, error) {
 	if err := validKey(key); err != nil {
 		return nil, err
 	}
@@ -51,12 +51,12 @@ func (o *Overlayfs) Prepare(key string, parentName string) ([]containerd.Mount, 
 	return active.mounts(o.cache)
 }
 
-func (o *Overlayfs) Commit(name, key string) error {
+func (o *Overlay) Commit(name, key string) error {
 	active := o.getActive(key)
 	return active.commit(name)
 }
 
-func (o *Overlayfs) newActiveDir(key string) (*activeDir, error) {
+func (o *Overlay) newActiveDir(key string) (*activeDir, error) {
 	var (
 		hash = hash(key)
 		path = filepath.Join(o.root, "active", hash)
@@ -77,7 +77,7 @@ func (o *Overlayfs) newActiveDir(key string) (*activeDir, error) {
 	return a, nil
 }
 
-func (o *Overlayfs) getActive(key string) *activeDir {
+func (o *Overlay) getActive(key string) *activeDir {
 	return &activeDir{
 		path:         filepath.Join(o.root, "active", hash(key)),
 		snapshotsDir: filepath.Join(o.root, "snapshots"),

--- a/snapshot/overlay/overlay_test.go
+++ b/snapshot/overlay/overlay_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/docker/containerd"
 )
 
-func TestOverlayfs(t *testing.T) {
+func TestOverlay(t *testing.T) {
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	o, err := NewOverlayfs(root)
+	o, err := NewOverlay(root)
 	if err != nil {
 		t.Error(err)
 		return
@@ -45,13 +45,13 @@ func TestOverlayfs(t *testing.T) {
 	}
 }
 
-func TestOverlayfsCommit(t *testing.T) {
+func TestOverlayCommit(t *testing.T) {
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	o, err := NewOverlayfs(root)
+	o, err := NewOverlay(root)
 	if err != nil {
 		t.Error(err)
 		return
@@ -73,13 +73,13 @@ func TestOverlayfsCommit(t *testing.T) {
 	}
 }
 
-func TestOverlayfsOverlayMount(t *testing.T) {
+func TestOverlayOverlayMount(t *testing.T) {
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	o, err := NewOverlayfs(root)
+	o, err := NewOverlay(root)
 	if err != nil {
 		t.Error(err)
 		return
@@ -125,7 +125,7 @@ func TestOverlayfsOverlayMount(t *testing.T) {
 	}
 }
 
-func TestOverlayfsOverlayRead(t *testing.T) {
+func TestOverlayOverlayRead(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("not running as root")
 	}
@@ -134,7 +134,7 @@ func TestOverlayfsOverlayRead(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(root)
-	o, err := NewOverlayfs(root)
+	o, err := NewOverlay(root)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
I think the terminology should be consistent in Phase One.

This PR replaces `LayerManipulator` and `SnapshotManipulator`  with `SnapshotManager`.
Please let me know if the opposite direction is correct.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>