### PR TITLE
shim executor: fix panic due to a nil context

### DIFF
--- a/execution/error.go
+++ b/execution/error.go
@@ -3,6 +3,7 @@ package execution
 import "fmt"
 
 var (
+	ErrContextIsNil      = fmt.Errorf("nil context was passed")
 	ErrProcessNotFound   = fmt.Errorf("process not found")
 	ErrProcessNotExited  = fmt.Errorf("process has not exited")
 	ErrContainerNotFound = fmt.Errorf("container not found")

--- a/execution/executors/shim/process.go
+++ b/execution/executors/shim/process.go
@@ -22,6 +22,7 @@ import (
 )
 
 type newProcessOpts struct {
+	ctx         context.Context
 	shimBinary  string
 	runtime     string
 	runtimeArgs []string
@@ -31,6 +32,9 @@ type newProcessOpts struct {
 }
 
 func newProcess(ctx context.Context, o newProcessOpts) (*process, error) {
+	if o.ctx == nil {
+		return nil, errors.New(execution.ErrContextIsNil.Error())
+	}
 	procStateDir, err := o.container.StateDir().NewProcess(o.ID)
 	if err != nil {
 		return nil, err
@@ -71,6 +75,7 @@ func newProcess(ctx context.Context, o newProcessOpts) (*process, error) {
 	}()
 
 	process := &process{
+		ctx:         o.ctx,
 		root:        procStateDir,
 		id:          o.ID,
 		exitChan:    make(chan struct{}),
@@ -89,7 +94,9 @@ func newProcess(ctx context.Context, o newProcessOpts) (*process, error) {
 	return process, nil
 }
 
-func loadProcess(root, id string) (*process, error) {
+// loadProcess returns a process.
+// pCtx is set to process.ctx
+func loadProcess(pCtx context.Context, root, id string) (*process, error) {
 	pid, err := runc.ReadPidFile(filepath.Join(root, pidFilename))
 	if err != nil {
 		return nil, err
@@ -123,6 +130,7 @@ func loadProcess(root, id string) (*process, error) {
 	}()
 
 	p := &process{
+		ctx:         pCtx,
 		root:        root,
 		id:          id,
 		pid:         int64(pid),


### PR DESCRIPTION
Shim executor was panicking due to a nil context on `ctr exec`.

```console
DEBU[4081] StartProcess()                                container=&{bar /home/suda/tmp/ocibundle/busybox /run/containerd/shim/bar 30110 created map[init:0xc420132f00]} module="containerd/execution/shim" options={dummy {false {80 80} {0 0 [] } [/bin/ps] [] / [] [] true  } false /tmp/ctr/bar-271920784/stdin /tmp/ctr/bar-271920784/stdout /tmp/ctr/bar-271920784/stderr}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x55c0b1db1ba6]

goroutine 4293 [running]:
panic(0x55c0b2190e80, 0xc4200120c0)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/docker/containerd/log.GetLogger(0x0, 0x0, 0x0)
        /home/suda/gopath/src/github.com/docker/containerd/log/context.go:35 +0x26
github.com/docker/containerd/execution/executors/shim.(*process).Wait(0xc420138c80, 0xc420546708, 0x55c0b1c63f0b, 0xc42052c0c8)
        /home/suda/gopath/src/github.com/docker/containerd/execution/executors/shim/process.go:190 +0x7e
github.com/docker/containerd/execution.(*Service).monitorProcess.func1(0x55c0b271c460, 0xc420138c80, 0xc420131810, 0xc4201f2740, 0x7fc2830a7338, 0xc420384e40)
        /home/suda/gopath/src/github.com/docker/containerd/execution/service.go:252 +0x49
created by github.com/docker/containerd/execution.(*Service).monitorProcess
        /home/suda/gopath/src/github.com/docker/containerd/execution/service.go:265 +0x71
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>