### PR TITLE
shim executor: clean state dir if newProcess() failed

### DIFF
--- a/execution/executors/shim/process.go
+++ b/execution/executors/shim/process.go
@@ -35,6 +35,11 @@ func newProcess(ctx context.Context, o newProcessOpts) (*process, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			o.container.StateDir().DeleteProcess(o.ID)
+		}
+	}()
 
 	exitPipe, controlPipe, err := getControlPipes(procStateDir)
 	if err != nil {


### PR DESCRIPTION
1.  process state dir was not removed when `newProcess()` failed
2. ~~Some `defer func(){if err != nil }` statements was not effective due to scopes of `err`. Such statements is hard to maintain. Probably they should be replaced with better code in the future.~~

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>