### PR TITLE
shim executor: fix an issue about empty stateDir

### DIFF
--- a/execution/executors/shim/process.go
+++ b/execution/executors/shim/process.go
@@ -31,7 +31,32 @@ type newProcessOpts struct {
 	execution.StartProcessOpts
 }
 
+func validateNewProcessOpts(o newProcessOpts) error {
+	if o.shimBinary == "" {
+		return errors.New("shim binary not specified")
+	}
+	if o.runtime == "" {
+		return errors.New("runtime not specified")
+	}
+	if o.container == nil {
+		return errors.New("container not specified")
+	}
+	if o.container.ID() == "" {
+		return errors.New("container id not specified")
+	}
+	if o.container.Bundle() == "" {
+		return errors.New("bundle not specified")
+	}
+	if o.stateDir == "" {
+		return errors.New("state dir not specified")
+	}
+	return nil
+}
+
 func newProcess(ctx context.Context, o newProcessOpts) (p *process, err error) {
+	if err = validateNewProcessOpts(o); err != nil {
+		return
+	}
 	p = &process{
 		id:       o.ID,
 		stateDir: o.stateDir,

--- a/execution/executors/shim/shim.go
+++ b/execution/executors/shim/shim.go
@@ -227,6 +227,7 @@ func (s *ShimRuntime) StartProcess(ctx context.Context, c *execution.Container, 
 		runtimeArgs:      s.runtimeArgs,
 		container:        c,
 		exec:             true,
+		stateDir:         c.ProcessStateDir(o.ID),
 		StartProcessOpts: o,
 	}
 


### PR DESCRIPTION
A new process could not be created because of an error caused by an empty
stateDir string

  $ ctr exec ...
  rpc error: code = 2 desc = failed to create process state dir: mkdir : no such file or directory

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>