### PR TITLE
shim executor: print shim-log.json on shim failure

### DIFF
--- a/execution/executors/shim/shim.go
+++ b/execution/executors/shim/shim.go
@@ -26,6 +26,7 @@ const (
 	exitPipeFilename    = "exit"
 	controlPipeFilename = "control"
 	exitStatusFilename  = "exitStatus"
+	shimLogFileName     = "shim-log.json"
 )
 
 func New(ctx context.Context, root, shim, runtime string, runtimeArgs []string) (*ShimRuntime, error) {


### PR DESCRIPTION
example output (with too newer runc):

```console
$ ctr --debug run --tty  -b ~/tmp/ocibundle/busybox foo
rpc error: code = 2 desc = shim exited prematurely with exit code 0 (log: "{\"level\": \"warn\",\"msg\": \"invalid argument\"}")
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>