### PR TITLE
Revert "io: stop screwing with \n in console output"

### DIFF
--- a/containerd-shim/console.go
+++ b/containerd-shim/console.go
@@ -16,9 +16,6 @@ func newConsole(uid, gid int) (*os.File, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	if err = saneTerminal(master); err != nil {
-		return nil, "", err
-	}
 	console, err := ptsname(master)
 	if err != nil {
 		return nil, "", err
@@ -33,29 +30,6 @@ func newConsole(uid, gid int) (*os.File, string, error) {
 		return nil, "", err
 	}
 	return master, console, nil
-}
-
-// saneTerminal sets the necessary tty_ioctl(4)s to ensure that a pty pair
-// created by us acts normally. In particular, a not-very-well-known default of
-// Linux unix98 ptys is that they have +onlcr by default. While this isn't a
-// problem for terminal emulators, because we relay data from the terminal we
-// also relay that funky line discipline.
-func saneTerminal(terminal *os.File) error {
-	// Go doesn't have a wrapper for any of the termios ioctls.
-	var termios syscall.Termios
-
-	if err := ioctl(terminal.Fd(), syscall.TCGETS, uintptr(unsafe.Pointer(&termios))); err != nil {
-		return fmt.Errorf("ioctl(tty, tcgets): %s", err.Error())
-	}
-
-	// Set -onlcr so we don't have to deal with \r.
-	termios.Oflag &^= syscall.ONLCR
-
-	if err := ioctl(terminal.Fd(), syscall.TCSETS, uintptr(unsafe.Pointer(&termios))); err != nil {
-		return fmt.Errorf("ioctl(tty, tcsets): %s", err.Error())
-	}
-
-	return nil
 }
 
 func ioctl(fd uintptr, flag, data uintptr) error {


### PR DESCRIPTION
Reverts docker/containerd#428

This causes issue with docker terminal processing (see https://github.com/docker/docker/pull/30226#issuecomment-273360577), so reverting until a solution is found as other fixes from `containerd` are needed to be vendored in.