### PR TITLE
Adding dist to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PACKAGES=$(shell go list ./... | grep -v /vendor/)
 INTEGRATION_PACKAGE=${PROJECT_ROOT}/integration
 
 # Project binaries.
-COMMANDS=ctr containerd containerd-shim protoc-gen-gogoctrd
+COMMANDS=ctr containerd containerd-shim protoc-gen-gogoctrd dist
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
 # TODO(stevvooe): This will set version from git tag, but overrides major,


### PR DESCRIPTION
minor update in Makefile to auto-compile/install ``dist``  with rest of contained binaries.

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>