### PR TITLE
[Enhencement] Dockerd do not respect log level settings other than `debug'.

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -49,6 +49,11 @@ high performance container runtime
 			Usage: "enable debug output in logs",
 		},
 		cli.StringFlag{
+			Name:  "log-level",
+			Usage: "Set the logging level (\"debug\", \"info\", \"warn\", \"error\", \"fatal\"",
+			Value: "info",
+		},
+		cli.StringFlag{
 			Name:  "root",
 			Usage: "containerd state directory",
 			Value: "/run/containerd",
@@ -77,6 +82,13 @@ high performance container runtime
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)
+		}
+		if logLevel := context.GlobalString("log-level"); logLevel != "" {
+			lvl, err := logrus.ParseLevel(logLevel)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to parse logging level: %s\n", logLevel)
+			}
+			logrus.SetLevel(lvl)
 		}
 		return nil
 	}


### PR DESCRIPTION
[enhencement] Dockerd do not respect log level settings other than `debug`.  #30349

Signed-off-by: Daniel Zhang <jmzwcn@gmail.com>