### PR TITLE
snapshot: Separate tests using root from non-root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /bin/
-*/coverage.txt
+**/coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ install:
   - export PATH=$PATH:/tmp/protobuf/bin/
 
 script:
-  - sudo PATH=$PATH GOPATH=$GOPATH make binaries coverage
+  - make binaries
+  - make coverage
+  - sudo PATH=$PATH GOPATH=$GOPATH make root-coverage

--- a/snapshot/btrfs/btrfs_test.go
+++ b/snapshot/btrfs/btrfs_test.go
@@ -19,6 +19,7 @@ const (
 )
 
 func TestBtrfs(t *testing.T) {
+	testutil.RequiresRoot(t)
 	device := setupBtrfsLoopbackDevice(t)
 	defer removeBtrfsLoopbackDevice(t, device)
 	root, err := ioutil.TempDir(device.mountPoint, "TestBtrfsPrepare-")

--- a/snapshot/manager_test.go
+++ b/snapshot/manager_test.go
@@ -14,6 +14,7 @@ import (
 // examples we've discussed thus far. It does perform mounts, so you must run
 // as root.
 func TestSnapshotManagerBasic(t *testing.T) {
+	testutil.RequiresRoot(t)
 	tmpDir, err := ioutil.TempDir("", "test-sm-")
 	if err != nil {
 		t.Fatal(err)

--- a/snapshot/naive/naive_test.go
+++ b/snapshot/naive/naive_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/docker/containerd"
+	"github.com/docker/containerd/snapshot/testutil"
 )
 
 func TestSnapshotNaiveBasic(t *testing.T) {
+	testutil.RequiresRoot(t)
 	tmpDir, err := ioutil.TempDir("", "test-naive-")
 	if err != nil {
 		t.Fatal(err)

--- a/snapshot/overlay/overlay_test.go
+++ b/snapshot/overlay/overlay_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/docker/containerd"
+	"github.com/docker/containerd/snapshot/testutil"
 )
 
 func TestOverlay(t *testing.T) {
@@ -126,9 +127,7 @@ func TestOverlayOverlayMount(t *testing.T) {
 }
 
 func TestOverlayOverlayRead(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("not running as root")
-	}
+	testutil.RequiresRoot(t)
 	root, err := ioutil.TempDir("", "overlay")
 	if err != nil {
 		t.Fatal(err)

--- a/snapshot/testutil/helpers.go
+++ b/snapshot/testutil/helpers.go
@@ -1,13 +1,34 @@
 package testutil
 
 import (
+	"flag"
+	"os"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
+var rootEnabled bool
+
+func init() {
+	flag.BoolVar(&rootEnabled, "test.root", false, "enable tests that require root")
+}
+
+// Unmount unmounts a given mountPoint and sets t.Error if it fails
 func Unmount(t *testing.T, mountPoint string) {
 	t.Log("unmount", mountPoint)
 	if err := syscall.Unmount(mountPoint, 0); err != nil {
 		t.Error("Could not umount", mountPoint, err)
 	}
+}
+
+// RequiresRoot skips tests that require root, unless the test.root flag has
+// been set
+func RequiresRoot(t *testing.T) {
+	if !rootEnabled {
+		t.Skip("skipping test that requires root")
+		return
+	}
+	assert.Equal(t, 0, os.Getuid(), "This test must be run as root.")
 }


### PR DESCRIPTION
This is a follow-up to #422 that makes new targets in the Makefile specifically for running tests that require root.  I've added a build flag `root` to files where tests exist that require root and renamed those files to be `_root_test.go` instead of `_test.go`.  Travis [shows](https://travis-ci.org/samuelkarp/containerd/jobs/195269121) most of the tests running successfully without root and that the tests that require root are still running as well (compare `[no test files]` with time and coverage output for the `snapshot`, `btrfs`, and `naive` packages.