### PR TITLE
Prevent panic if exec process dies before sync channel is created

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -422,6 +422,12 @@ func (s *Supervisor) newExecSyncChannel(containerID, pid string) {
 	s.containerExecSyncLock.Unlock()
 }
 
+func (s *Supervisor) deleteExecSyncChannel(containerID, pid string) {
+	s.containerExecSyncLock.Lock()
+	delete(s.containerExecSync[containerID], pid)
+	s.containerExecSyncLock.Unlock()
+}
+
 func (s *Supervisor) getExecSyncChannel(containerID, pid string) chan struct{} {
 	s.containerExecSyncLock.Lock()
 	ch := s.containerExecSync[containerID][pid]


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>

-- 

Should prevent the panic while closing a nil channel sometimes seen.