### PR TITLE
dist: provide apply command to build rootfs

### DIFF
--- a/cmd/dist/apply.go
+++ b/cmd/dist/apply.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	contextpkg "context"
+	"os"
+
+	"github.com/docker/containerd/log"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/urfave/cli"
+)
+
+var applyCommand = cli.Command{
+	Name:      "apply",
+	Usage:     "apply layer from stdin to dir",
+	ArgsUsage: "[flags] <digest>",
+	Flags:     []cli.Flag{},
+	Action: func(context *cli.Context) error {
+		var (
+			ctx = contextpkg.Background()
+			dir = context.Args().First()
+		)
+
+		log.G(ctx).Info("applying layer from stdin")
+		if _, err := archive.ApplyLayer(dir, os.Stdin); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -35,6 +35,7 @@ distribution tool
 		pathCommand,
 		deleteCommand,
 		listCommand,
+		applyCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {


### PR DESCRIPTION
This changeset adds the simple apply command. It consumes a tar layer
and applies that layer to the specified directory. For the most part, it
is a direct call into Docker's `pkg/archive.ApplyLayer`.

The following demonstrates unpacking the wordpress rootfs into a local
directory `wordpress`:

```
$ ./dist fetch docker.io/library/wordpress 4.5 mediatype:application/vnd.docker.distribution.manifest.v2+json | \
    jq -r '.layers[] | "sudo ./dist apply ./wordpress < $(./dist path -n "+.digest+")"' | xargs -I{} -n1 sh -c "{}"
```

Note that you should have fetched the layers into the local content
store before running the above. Alternatively, you can just read the
manifest from the content store, rather than fetching it. We use fetch
above to avoid having to lookup the manifest digest for our demo.

This tool has a long way to go. We still need to incorporate
snapshotting, as well as the ability to calculate the `ChainID` under
subsequent unpacking. Once we have some tools to play around with
snapshotting, we'll be able to incorporate our `rootfs.ApplyLayer`
algorithm that will get us a lot closer to a production worthy system.

Signed-off-by: Stephen J Day <stephen.day@docker.com>