### PR TITLE
os.MkdirAll the containerd root dir

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -127,7 +127,7 @@ func main() {
 		switch runtime {
 		case "shim":
 			root := filepath.Join(context.GlobalString("root"), "shim")
-			err = os.Mkdir(root, 0700)
+			err = os.MkdirAll(root, 0700)
 			if err != nil && !os.IsExist(err) {
 				return err
 			}


### PR DESCRIPTION
containerd fails to start if run with `--root` pointing to a subdirectory, for example:

```
$ containerd --root /tmp/run/containerd
INFO[0000] listening and serving metrics                 metrics-address="127.0.0.1:7897" module=containerd
INFO[0000] starting nats-streaming-server                events-address="nats://localhost:4222" module=containerd
INFO[0000] run with runtime executor                     module=containerd runtime=shim
mkdir /tmp/run/containerd/shim: no such file or directory
```

This PR simply changes the `os.Mkdir` to an `os.MkdirAll`.

Signed-off-by: Ed King <ed@teddyking.co.uk>