### PR TITLE
Update log formatting

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -134,6 +134,7 @@ func main() {
 		logrus.SetFormatter(&logrus.TextFormatter{
 			TimestampFormat: time.RFC3339Nano,
 			DisableColors:   context.GlobalBool("raw-logs"),
+			FullTimestamp:   true,
 		})
 		setupDumpStacksTrap()
 		if context.GlobalBool("debug") {

--- a/containerd/main.go
+++ b/containerd/main.go
@@ -88,6 +88,10 @@ var daemonFlags = []cli.Flag{
 		Name:  "graphite-address",
 		Usage: "Address of graphite server",
 	},
+	cli.BoolFlag{
+		Name:  "raw-logs",
+		Usage: "disable logs fancy coloring and formatting",
+	},
 }
 
 // DumpStacks dumps the runtime stack.
@@ -117,7 +121,6 @@ func setupDumpStacksTrap() {
 }
 
 func main() {
-	logrus.SetFormatter(&logrus.TextFormatter{TimestampFormat: time.RFC3339Nano})
 	app := cli.NewApp()
 	app.Name = "containerd"
 	if containerd.GitCommit != "" {
@@ -128,6 +131,10 @@ func main() {
 	app.Usage = usage
 	app.Flags = daemonFlags
 	app.Before = func(context *cli.Context) error {
+		logrus.SetFormatter(&logrus.TextFormatter{
+			TimestampFormat: time.RFC3339Nano,
+			DisableColors:   context.GlobalBool("raw-logs"),
+		})
 		setupDumpStacksTrap()
 		if context.GlobalBool("debug") {
 			logrus.SetLevel(logrus.DebugLevel)


### PR DESCRIPTION
- Add a new `--raw-logs` flag to disable coloring and fancy formatting
- Make logrus always disable the timestamp instead of the delta since execution start

Closes #466