### PR TITLE
Skip containers with no processes: Fixes a possibility of a panic if process directory is empty.

### DIFF
--- a/execution/executors/shim/shim.go
+++ b/execution/executors/shim/shim.go
@@ -404,9 +404,15 @@ func (s *ShimRuntime) loadContainers() {
 			container.AddProcess(p)
 		}
 
-		// if successfull, add the container to our list
+		processes := container.Processes()
+		if len(processes) == 0 {
+			log.G(s.ctx).WithField("container-id", container.ID()).Warning("No processes found")
+			continue
+		}
+
+		// if successful, add the container to our list
 		if err == nil {
-			for _, p := range container.Processes() {
+			for _, p := range processes {
 				s.monitorProcess(p.(*process))
 			}
 			s.addContainer(container)


### PR DESCRIPTION
I ran into this panic when I tried to start containerd. At first look it tries to get a status and fails because of an empty interface. Drilling a bit deeper I discovered that container is loaded even if there is no data about running processes.  This fix discards such containers which do not have process related data.  (processes dir is empty)

```
DEBU[0000] List()                                        module="containerd/execution/shim"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x59216a]

goroutine 1 [running]:
panic(0x96f600, 0xc4200120a0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/docker/containerd/execution.(*Container).Status(0xc420071680, 0xef27c0, 0xc420268780)
	/root/go/src/github.com/docker/containerd/execution/container.go:101 +0x4a
github.com/docker/containerd/execution.New(0x7f82663f2040, 0xc420268780, 0xef53e0, 0xc420011800, 0xc420268780, 0xf, 0xa10591)
	/root/go/src/github.com/docker/containerd/execution/service.go:33 +0x125
main.main.func2(0xc42000fcc0, 0x0, 0x0)
	/root/go/src/github.com/docker/containerd/cmd/containerd/main.go:164 +0x11b8
github.com/docker/containerd/vendor/github.com/urfave/cli.HandleAction(0x951d40, 0xa7ce40, 0xc42000fcc0, 0xc420070ba0, 0x0)
	/root/go/src/github.com/docker/containerd/vendor/github.com/urfave/cli/app.go:485 +0xd4
github.com/docker/containerd/vendor/github.com/urfave/cli.(*App).Run(0xc4200916c0, 0xc42000c1c0, 0x2, 0x2, 0x0, 0x0)
	/root/go/src/github.com/docker/containerd/vendor/github.com/urfave/cli/app.go:259 +0x74f
main.main()
	/root/go/src/github.com/docker/containerd/cmd/containerd/main.go:198 +0x637
```

Signed-off-by: Volodymyr Burenin <vburenin@gmail.com>