### PR TITLE
content: fix panic during filepath.Walk()

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -173,6 +173,9 @@ func (cs *Store) Walk(fn WalkFunc) error {
 	root := filepath.Join(cs.root, "blobs")
 	var alg digest.Algorithm
 	return filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !fi.IsDir() && !alg.Available() {
 			return nil
 		}


### PR DESCRIPTION
`dist ls` was panicking when the `.content` directory does not exist.

Before:
```console
$ dist ls
DIGEST  SIZE    AGE
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x5572ce71cdb9]

goroutine 1 [running]:
panic(0x5572ce99c1c0, 0xc4200100f0)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/docker/containerd/content.(*Store).Walk.func1(0xc4200db8c0, 0x19, 0x0, 0x0, 0x5572ced6e340, 0xc420013860, 0xc4200db801, 0xc420013830)
        /home/suda/gopath/src/github.com/docker/containerd/content/content.go:176 +0x69
path/filepath.Walk(0xc4200db8c0, 0x19, 0xc420013830, 0xc4200db8c0, 0x19)
        /usr/local/go/src/path/filepath/path.go:396 +0x8b
github.com/docker/containerd/content.(*Store).Walk(0xc420011cf0, 0xc420011d00, 0x5572ce9f69d3, 0x10)
        /home/suda/gopath/src/github.com/docker/containerd/content/content.go:207 +0x143
main.glob..func6(0xc42001ab40, 0x0, 0x0)
        /home/suda/gopath/src/github.com/docker/containerd/cmd/dist/list.go:83 +0x14d
github.com/docker/containerd/vendor/github.com/urfave/cli.HandleAction(0x5572ce98c120, 0x5572cea1ee40, 0xc42001ab40, 0xc420018600, 0x0)
        /home/suda/gopath/src/github.com/docker/containerd/vendor/github.com/urfave/cli/app.go:485 +0xd4
github.com/docker/containerd/vendor/github.com/urfave/cli.Command.Run(0x5572ce9f2e26, 0x4, 0x0, 0x0, 0x5572ced63940, 0x1, 0x1, 0x5572ce9fbb42, 0x1c, 0x0, ...)
        /home/suda/gopath/src/github.com/docker/containerd/vendor/github.com/urfave/cli/command.go:193 +0xb96
github.com/docker/containerd/vendor/github.com/urfave/cli.(*App).Run(0xc420090d00, 0xc42000c580, 0x2, 0x2, 0x0, 0x0)
        /home/suda/gopath/src/github.com/docker/containerd/vendor/github.com/urfave/cli/app.go:250 +0x812
main.main()
        /home/suda/gopath/src/github.com/docker/containerd/cmd/dist/main.go:46 +0x3c3
```

After:
```console
$ dist ls
DIGEST  SIZE    AGE
lstat /home/suda/.content/blobs: no such file or directory
```


Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>