### PR TITLE
add oci subcommand to create oci-layout

### DIFF
--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -36,6 +36,7 @@ distribution tool
 		deleteCommand,
 		listCommand,
 		applyCommand,
+		ociCommand,
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {

--- a/cmd/dist/oci.go
+++ b/cmd/dist/oci.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"github.com/docker/containerd/content"
+	"github.com/opencontainers/go-digest"
+	"github.com/urfave/cli"
+)
+
+var ociCommand = cli.Command{
+	Name:      "oci",
+	Usage:     "create oci image layout",
+	ArgsUsage: "[flags] <ref> <manifest-digest>",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "blob-root",
+			Usage: "root path contains blobs",
+		},
+		cli.StringFlag{
+			Name:  "path, p",
+			Usage: "path to create oci layout",
+		},
+	},
+	Action: func(context *cli.Context) error {
+		var (
+			blobRoot = context.String("blob-root")
+			path     = context.String("path")
+			ref      = content.Ref(context.Args().First())
+			args     = context.Args().Tail()
+		)
+
+		if blobRoot == "" {
+			return fmt.Errorf("blob-root required")
+		}
+		if path == "" {
+			return fmt.Errorf("path required")
+		}
+
+		if ref == "" {
+			return fmt.Errorf("ref required")
+		}
+
+		if err := ref.Validate(); err != nil {
+			return err
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("manifest-digest required")
+		}
+		dgst := digest.Digest(args[0])
+
+		if err := dgst.Validate(); err != nil {
+			return err
+		}
+
+		return content.CreateOCILayout(path, blobRoot, ref, dgst)
+	},
+}

--- a/content/oci.go
+++ b/content/oci.go
@@ -1,0 +1,84 @@
+package content
+
+import (
+	"fmt"
+	"github.com/opencontainers/go-digest"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// // RefRegexp matches valid ref types.
+var RefRegexp = regexp.MustCompile(`[a-zA-Z0-9-._]+`)
+
+var (
+	ErrRefFormat = fmt.Errorf("invalid ref format")
+)
+
+type Ref string
+
+func (ref Ref) Validate() error {
+	if !RefRegexp.MatchString(string(ref)) {
+		return ErrRefFormat
+	}
+	return nil
+}
+
+func CreateOCILayout(path string, blobRoot string, ref Ref, manifestDigest digest.Digest) error {
+
+	size, err := validateManifest(blobRoot, manifestDigest)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+
+	if err := createLayoutFile(path); err != nil {
+		return err
+	}
+
+	refsDir := filepath.Join(path, "refs")
+	if err := os.MkdirAll(refsDir, 0755); err != nil {
+		return err
+	}
+	descriptor := fmt.Sprintf(`{"size":%d,"digest":"%s","mediaType":"application/vnd.oci.image.manifest.list.v1+json"}`, size, manifestDigest.String())
+
+	//Write ref event if it has already exists, as an update action.
+	if err := ioutil.WriteFile(filepath.Join(refsDir, string(ref)), []byte(descriptor), 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createLayoutFile(path string) error {
+	layoutFile := filepath.Join(path, "oci-layout")
+	if _, e := os.Stat(layoutFile); os.IsNotExist(e) {
+		if err := ioutil.WriteFile(layoutFile, []byte(`{"imageLayoutVersion":"1.0.0"}`), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateManifest(blobRoot string, manifestDigest digest.Digest) (int64, error) {
+	cs, err := Open(blobRoot)
+	if err != nil {
+		return 0, err
+	}
+
+	manifest := cs.blobPath(manifestDigest)
+
+	stat, err := os.Stat(manifest)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, fmt.Errorf("manifest %s is not exists.", manifestDigest)
+		}
+		return 0, err
+	}
+
+	//TODO check manifest format
+	return stat.Size(), nil
+}


### PR DESCRIPTION
now we can use `dist` manage blobs, but it's not enough. At least we must store and reference manifest locally. 

with this tool, the users could create a standand oci image layout, and then it could be used to create a bundle with command `dist apply <layout-dir> <ref>`

The follow script show an complete process to create oci image layout with `dist`

```
manifest=$(./dist fetch docker.io/library/redis latest mediatype:application/vnd.docker.distribution.manifest.v2+json)

# ingress config and layers
echo "$manifest" | jq -r '.config,.layers[] | "./dist fetch docker.io/library/redis "+.digest + "| ./dist ingest --expected-digest "+.digest+" --expected-size "+(.size | tostring) +" docker.io/library/redis@"+.digest' | xargs -I{} -P10 -n1 sh -c "{}"

#convert to oci media types.
oci_manifest=$(echo "$manifest"| \
    sed -e 's/vnd.docker.distribution.manifest.v2+json/vnd.oci.image.manifest.v1+json/' \
        -e 's/vnd.docker.image.rootfs.diff.tar.gzip/vnd.oci.image.layer.v1.tar+gzip/' \
        -e 's/vnd.docker.container.image.v1+json/vnd.oci.image.config.v1+json/')  

#ingress manifest
digest=$(echo -n "$oci_manifest" | sha256sum | cut -d' ' -f1)
echo -n "$oci_manifest" | ./dist ingest --expected-digest sha256:$digest --expected-size ${#oci_manifest} docker.io/library/redis@$digest

# create oci image layout
./dist oci --blob-root ./.content --path docker.io/library/redis latest sha256:$digest
```

Here is the filesystem structure

```
$ tree docker.io
docker.io
└── library
    └── redis
        ├── oci-layout
        └── refs
            └── latest
```

I didn't create blobs directory, since all blobs had already stored under .content.

Signed-off-by: Jizhong <jiangjizhong@gmail.com>