### PR TITLE
use bitclear instead of seperating it and fix some typo

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -86,7 +86,7 @@ func parseMountOptions(options []string) (int, string) {
 		// then it is a data value for a specific fs type
 		if f, exists := flags[o]; exists && f.flag != 0 {
 			if f.clear {
-				flag &= ^f.flag
+				flag &^= f.flag
 			} else {
 				flag |= f.flag
 			}

--- a/sys/prctl.go
+++ b/sys/prctl.go
@@ -26,7 +26,7 @@ const prSetChildSubreaper = 36
 
 // PR_GET_CHILD_SUBREAPER allows retrieving the current child
 // subreaper.
-// Return the "child subreaper" setting of the caller, in the
+// Returns the "child subreaper" setting of the caller, in the
 // location pointed to by (int *) arg2.
 const prGetChildSubreaper = 37
 


### PR DESCRIPTION
Signed-off-by: kevinetc123 <kaiwentan@harmonycloud.cn>