### PR TITLE
supervisor: print runtime's log on failure of ContainerCreate()

### DIFF
--- a/supervisor/shim_test.go
+++ b/supervisor/shim_test.go
@@ -1,0 +1,47 @@
+package supervisor
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseRuntimeLog(t *testing.T) {
+	s := `{"level": "error", "msg": "foo\n", "time": "2017-01-01T00:00:42Z"}
+{"level": "error", "msg": "bar\n", "time": "2017-01-01T00:00:43Z"}
+`
+	testCases := []struct {
+		entries  int
+		expected []map[string]interface{}
+	}{
+		{
+			entries: 0,
+			expected: []map[string]interface{}{
+				map[string]interface{}{"level": "error", "msg": "foo\n", "time": "2017-01-01T00:00:42Z"},
+				map[string]interface{}{"level": "error", "msg": "bar\n", "time": "2017-01-01T00:00:43Z"},
+			},
+		},
+		{
+			entries: 1,
+			expected: []map[string]interface{}{
+				map[string]interface{}{"level": "error", "msg": "bar\n", "time": "2017-01-01T00:00:43Z"}},
+		},
+		{
+			entries: 2,
+			expected: []map[string]interface{}{
+				map[string]interface{}{"level": "error", "msg": "foo\n", "time": "2017-01-01T00:00:42Z"},
+				map[string]interface{}{"level": "error", "msg": "bar\n", "time": "2017-01-01T00:00:43Z"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := parseRuntimeLog(strings.NewReader(s), tc.entries)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(tc.expected, got) {
+			t.Fatalf("expected %v, got %v", tc.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
e.g. when ctr run foo is attempted without specifying --bundle, the daemon prints:
```
WARN[0023] shim log (last 1 entry): [map[msg:JSON specification file config.json not found
 time:2017-02-13T05:24:41Z level:error]]  container=foo module="containerd/execution/supervisor"
```

Replaces https://github.com/docker/containerd/pull/505 (which had shim API for fetching logs)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>