### PR TITLE
snapshotter: add more assertion

### DIFF
--- a/archive/tar_test.go
+++ b/archive/tar_test.go
@@ -56,15 +56,15 @@ func TestDiffApply(t *testing.T) {
 			fstest.CreateFile("/home/derek/.zshrc", []byte("#ZSH is just better\n"), 0640),
 		),
 		fstest.Apply(
-			fstest.RemoveFile("/etc/badfile"),
+			fstest.Remove("/etc/badfile"),
 			fstest.Rename("/home/derek", "/home/notderek"),
 		),
 		fstest.Apply(
-			fstest.RemoveFile("/usr"),
-			fstest.RemoveFile("/etc/hosts.allow"),
+			fstest.RemoveAll("/usr"),
+			fstest.Remove("/etc/hosts.allow"),
 		),
 		fstest.Apply(
-			fstest.RemoveFile("/home"),
+			fstest.RemoveAll("/home"),
 			fstest.CreateDir("/home/derek", 0700),
 			fstest.CreateFile("/home/derek/.bashrc", []byte("#not going away\n"), 0640),
 			// "/etc/hosts" must be touched to be hardlinked in same layer
@@ -92,14 +92,14 @@ func TestDiffApplyDeletion(t *testing.T) {
 			fstest.CreateFile("/test/b", []byte{}, 0644),
 			fstest.CreateDir("/test/otherdir", 0755),
 			fstest.CreateFile("/test/otherdir/.empty", []byte{}, 0644),
-			fstest.RemoveFile("/lib"),
+			fstest.RemoveAll("/lib"),
 			fstest.CreateDir("/lib", 0700),
 			fstest.CreateFile("/lib/not-hidden", []byte{}, 0644),
 		),
 		fstest.Apply(
-			fstest.RemoveFile("/test/a"),
-			fstest.RemoveFile("/test/b"),
-			fstest.RemoveFile("/test/otherdir"),
+			fstest.Remove("/test/a"),
+			fstest.Remove("/test/b"),
+			fstest.RemoveAll("/test/otherdir"),
 			fstest.CreateFile("/lib/newfile", []byte{}, 0644),
 		),
 	}

--- a/fs/diff_test.go
+++ b/fs/diff_test.go
@@ -33,7 +33,7 @@ func TestSimpleDiff(t *testing.T) {
 		fstest.CreateFile("/etc/profile", []byte("PATH=/usr/bin"), 0666),
 		fstest.CreateDir("/root", 0700),
 		fstest.CreateFile("/root/.bashrc", []byte("PATH=/usr/sbin:/usr/bin"), 0644),
-		fstest.RemoveFile("/etc/unexpected"),
+		fstest.Remove("/etc/unexpected"),
 	)
 	diff := []testChange{
 		Modify("/etc/hosts"),
@@ -57,7 +57,7 @@ func TestDirectoryReplace(t *testing.T) {
 	)
 	l2 := fstest.Apply(
 		fstest.CreateFile("/dir1/f11", []byte("#New file here"), 0644),
-		fstest.RemoveFile("/dir1/f2"),
+		fstest.RemoveAll("/dir1/f2"),
 		fstest.CreateFile("/dir1/f2", []byte("Now file"), 0666),
 	)
 	diff := []testChange{
@@ -77,7 +77,7 @@ func TestRemoveDirectoryTree(t *testing.T) {
 		fstest.CreateFile("/dir1/dir2/f2", []byte("f2"), 0644),
 	)
 	l2 := fstest.Apply(
-		fstest.RemoveFile("/dir1"),
+		fstest.RemoveAll("/dir1"),
 	)
 	diff := []testChange{
 		Delete("/dir1"),
@@ -93,7 +93,7 @@ func TestFileReplace(t *testing.T) {
 		fstest.CreateFile("/dir1", []byte("a file, not a directory"), 0644),
 	)
 	l2 := fstest.Apply(
-		fstest.RemoveFile("/dir1"),
+		fstest.Remove("/dir1"),
 		fstest.CreateDir("/dir1/dir2", 0755),
 		fstest.CreateFile("/dir1/dir2/f1", []byte("also a file"), 0644),
 	)

--- a/fs/fstest/compare.go
+++ b/fs/fstest/compare.go
@@ -1,6 +1,9 @@
 package fstest
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/stevvooe/continuity"
 )
@@ -34,4 +37,17 @@ func CheckDirectoryEqual(d1, d2 string) error {
 	}
 
 	return nil
+}
+
+// CheckDirectoryEqualWithApplier compares directory against applier
+func CheckDirectoryEqualWithApplier(root string, a Applier) error {
+	applied, err := ioutil.TempDir("", "fstest")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(applied)
+	if err := a.Apply(applied); err != nil {
+		return err
+	}
+	return CheckDirectoryEqual(applied, root)
 }

--- a/fs/fstest/file.go
+++ b/fs/fstest/file.go
@@ -37,8 +37,16 @@ func CreateFile(name string, content []byte, perm os.FileMode) Applier {
 	})
 }
 
-// RemoveFile returns a file applier which removes the provided file name
-func RemoveFile(name string) Applier {
+// Remove returns a file applier which removes the provided file name
+func Remove(name string) Applier {
+	return applyFn(func(root string) error {
+		return os.Remove(filepath.Join(root, name))
+	})
+}
+
+// RemoveAll returns a file applier which removes the provided file name
+// as in os.RemoveAll
+func RemoveAll(name string) Applier {
 	return applyFn(func(root string) error {
 		return os.RemoveAll(filepath.Join(root, name))
 	})


### PR DESCRIPTION
This PR adds new assertions to make sure that the content of the parent committed snapshot is propagated to the child active one.

I added `testutil.AssertTree()` for asserting file hiearchy in a declarative way.
I think we should use [continuity](https://github.com/stevvooe/continuity) in the future instead of this utility function.
(requires https://github.com/stevvooe/continuity/issues/48)

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>