### PR TITLE
Add the short/quick/memorable URL for Slack Community from Victor Coisne

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This will be the best place to discuss design and implementation.
 
 For sync communication we have a community slack with a #containerd channel that everyone is welcome to join and chat about development.
 
-**Slack:** http://dockr.ly/MeetUp
+**Slack:** http://dockr.ly/community
 
 ### Developer Quick-Start
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This will be the best place to discuss design and implementation.
 
 For sync communication we have a community slack with a #containerd channel that everyone is welcome to join and chat about development.
 
-**Slack:** https://community.docker.com/registrations/groups/4316
+**Slack:** http://dockr.ly/MeetUp
 
 ### Developer Quick-Start
 


### PR DESCRIPTION
Victor set up a short URL for the Slack Community sign-up process.

This is more memorable / easier to share.

Thoughts on updating URL @stevvooe ?

Signed-off-by: Alex Ellis <alexellis2@gmail.com>