### PR TITLE
version: finish version setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ DESTDIR=/usr/local
 # Used to populate version variable in main package.
 VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
 
-PROJECT_ROOT=github.com/docker/containerd
+PKG=github.com/docker/containerd
 
 # Project packages.
 PACKAGES=$(shell go list ./... | grep -v /vendor/)
-INTEGRATION_PACKAGE=${PROJECT_ROOT}/integration
+INTEGRATION_PACKAGE=${PKG}/integration
 SNAPSHOT_PACKAGES=$(shell go list ./snapshot/...)
 
 # Project binaries.
@@ -21,7 +21,7 @@ BINARIES=$(addprefix bin/,$(COMMANDS))
 # TODO(stevvooe): This will set version from git tag, but overrides major,
 # minor, patch in the actual file. We'll have to resolve this before release
 # time.
-GO_LDFLAGS=-ldflags "-X `go list`.Version=$(VERSION)"
+GO_LDFLAGS=-ldflags "-X $(PKG).Version=$(VERSION) -X $(PKG).Package=$(PKG)"
 
 # Flags passed to `go test`
 TESTFLAGS ?=-parallel 8 -race
@@ -108,8 +108,8 @@ FORCE:
 
 # Build a binary from a cmd.
 bin/%: cmd/% FORCE
-	@test $$(go list) = "${PROJECT_ROOT}" || \
-		(echo "👹 Please correctly set up your Go build environment. This project must be located at <GOPATH>/src/${PROJECT_ROOT}" && false)
+	@test $$(go list) = "${PKG}" || \
+		(echo "👹 Please correctly set up your Go build environment. This project must be located at <GOPATH>/src/${PKG}" && false)
 	@echo "🐳 $@"
 	@go build -i -o $@ ${GO_LDFLAGS}  ${GO_GCFLAGS} ./$<
 

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -43,6 +43,12 @@ var (
 	global = log.WithModule(gocontext.Background(), "containerd")
 )
 
+func init() {
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Println(c.App.Name, containerd.Package, c.App.Version)
+	}
+}
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "containerd"

--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -9,6 +9,12 @@ import (
 	"github.com/urfave/cli"
 )
 
+func init() {
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Println(c.App.Name, containerd.Package, c.App.Version)
+	}
+}
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "ctr"

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -15,6 +15,9 @@ var (
 )
 
 func main() {
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Println(os.Args[0], containerd.Package, containerd.Version)
+	}
 	app := cli.NewApp()
 	app.Name = "dist"
 	app.Version = containerd.Version

--- a/version.go
+++ b/version.go
@@ -1,20 +1,12 @@
 package containerd
 
-import "fmt"
+var (
+	Package = "github.com/docker/containerd"
 
-// VersionMajor holds the release major number
-const VersionMajor = 1
+	// Version holds the complete version number.
+	Version = "1.0-dev+unknown"
 
-// VersionMinor holds the release minor number
-const VersionMinor = 0
-
-// VersionPatch holds the release patch number
-const VersionPatch = 0
-
-// Version holds the combination of major minor and patch as a string
-// of format Major.Minor.Patch
-var Version = fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
-
-// GitCommit is filled with the Git revision being used to build the
-// program at linking time
-var GitCommit = ""
+	// GitCommit is filled with the Git revision being used to build the
+	// program at linking time
+	GitCommit = ""
+)


### PR DESCRIPTION
This setup will now correctly set the version number from the git tag.
When using `--version`, we will see the binary name, the package it was
built from and a git hash based on the tag:

```console
$./bin/dist -v
./bin/dist github.com/docker/containerd 0b45d91.m
```

Note that in the above example, if we set a tag of `v1.0.0-dev`, that
will show up in the version number, as follows:

```console
$./bin/dist -v
./bin/dist github.com/docker/containerd v1.0.0-dev
```

Once commits are made past that tag, the version number will be
expressed relative to that tag and include a git hash:

```console
$./bin/dist -v
./bin/dist github.com/docker/containerd v1.0.0-dev-1-g7953e96.m
```

Some these examples include a `.m` postfix. This indicates that the
binary was build from a source tree with local modifications.

We can add a dev tag to start getting 1.0 version numbers for test
builds.

Signed-off-by: Stephen J Day <stephen.day@docker.com>