### PR TITLE
Remove no longer applicable TODO comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ SNAPSHOT_PACKAGES=$(shell go list ./snapshot/...)
 COMMANDS=ctr containerd containerd-shim protoc-gen-gogoctrd dist ctrd-protobuild
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
-# TODO(stevvooe): This will set version from git tag, but overrides major,
-# minor, patch in the actual file. We'll have to resolve this before release
-# time.
 GO_LDFLAGS=-ldflags "-X $(PKG).Version=$(VERSION) -X $(PKG).Package=$(PKG)"
 
 # Flags passed to `go test`


### PR DESCRIPTION
After the version PR (#561), this TODO message no longer applies. // cc: @stevvooe 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>