### PR TITLE
golang plugin package dependency requires 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For sync communication we have a community slack with a #containerd channel that
 
 To build the daemon and `ctr` simple test client, the following build system dependencies are required:
 
-* Go 1.7.x or above
+* Go 1.8.x or above (requires 1.8 due to use of golang plugin(s))
 * Protoc 3.x compiler and headers (download at the [Google protobuf releases page](https://github.com/google/protobuf/releases))
 
 For proper results, install the `protoc` release into `/usr/local` on your build system. For example, the following commands will download and install the 3.1.0 release for a 64-bit Linux host:


### PR DESCRIPTION
Minor update to README.md to mention the 1.8 requirement.. otherwise one will receive the following build error:
```
mike@mike-VirtualBox:~/go/src/github.com/docker/containerd$ make binaries
🐳 bin/ctr
plugin.go:6:2: cannot find package "plugin" in any of:
	/home/mike/go/src/github.com/docker/containerd/vendor/plugin (vendor tree)
	/usr/local/go/src/plugin (from $GOROOT)
	/home/mike/go/src/plugin (from $GOPATH)
```
Signed-off-by: Mike Brown <brownwm@us.ibm.com>