### PR TITLE
Change linux runtime(w shim) to builtin

### DIFF
--- a/cmd/containerd/builtins.go
+++ b/cmd/containerd/builtins.go
@@ -2,6 +2,7 @@ package main
 
 // register containerd builtins here
 import (
+	_ "github.com/docker/containerd/linux"
 	_ "github.com/docker/containerd/services/content"
 	_ "github.com/docker/containerd/services/execution"
 )

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,7 +1,0 @@
-
-all:
-	go build -buildmode=plugin -o shim-linux-amd64.so
-
-install:
-	mkdir -p /var/lib/containerd/plugins
-	cp shim-linux-amd64.so /var/lib/containerd/plugins/

--- a/linux/container.go
+++ b/linux/container.go
@@ -1,4 +1,4 @@
-package main
+package linux
 
 import (
 	"github.com/docker/containerd"

--- a/linux/main.go
+++ b/linux/main.go
@@ -1,5 +1,0 @@
-package main
-
-func main() {
-	panic("build as plugin not executable")
-}

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -1,4 +1,4 @@
-package main
+package linux
 
 import (
 	"bytes"

--- a/linux/shim.go
+++ b/linux/shim.go
@@ -1,4 +1,4 @@
-package main
+package linux
 
 import (
 	"fmt"


### PR DESCRIPTION
Because of the plugin findings and having the default runtime builtin
this makes it much better for development and testing.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>