### PR TITLE
cmd/dist: consistently replace version string

### DIFF
--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -14,10 +14,14 @@ var (
 	background = contextpkg.Background()
 )
 
-func main() {
+func init() {
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Println(os.Args[0], containerd.Package, containerd.Version)
+		fmt.Println(c.App.Name, containerd.Package, c.App.Version)
 	}
+
+}
+
+func main() {
 	app := cli.NewApp()
 	app.Name = "dist"
 	app.Version = containerd.Version


### PR DESCRIPTION
A previous PR placed the version string replacement in the `init`
function in the other commands. This makes this same change consistently
in the `dist` tool.

Signed-off-by: Stephen J Day <stephen.day@docker.com>