### PR TITLE
cmd/dist/fetch: address subtle concurrency bug

### DIFF
--- a/cmd/dist/fetch.go
+++ b/cmd/dist/fetch.go
@@ -139,11 +139,11 @@ func getResolver(ctx contextpkg.Context) (remotes.Resolver, error) {
 			}
 
 			for _, path := range paths {
-				base.Path = path
-				url := base.String()
+				url := base
+				url.Path = path
 				log.G(ctx).WithField("url", url).Debug("fetch content")
 
-				req, err := http.NewRequest(http.MethodGet, url, nil)
+				req, err := http.NewRequest(http.MethodGet, url.String(), nil)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
When using the fetcher concurrently, the loop modifying the closed
`base` parameter was causing urls from different digests to be returned
randomly. We copy the the value and then modify it to make it work
correctly.

Luckily, we are using content addressable storage or this would have
been undetectable.

Signed-off-by: Stephen J Day <stephen.day@docker.com>