### PR TITLE
Test cases added for to test Stat() Interface.

### DIFF
--- a/snapshot/snapshotter.go
+++ b/snapshot/snapshotter.go
@@ -217,6 +217,8 @@ type Snapshotter interface {
 // SnapshotterSuite runs a test suite on the snapshotter given a factory function.
 func SnapshotterSuite(t *testing.T, name string, snapshotterFn func(root string) (Snapshotter, func(), error)) {
 	t.Run("Basic", makeTest(t, name, snapshotterFn, checkSnapshotterBasic))
+	t.Run("StatActive", makeTest(t, name, snapshotterFn, checkSnapshotterStatActive))
+	t.Run("StatComitted", makeTest(t, name, snapshotterFn, checkSnapshotterStatCommitted))
 }
 
 func makeTest(t *testing.T, name string, snapshotterFn func(root string) (Snapshotter, func(), error), fn func(t *testing.T, snapshotter Snapshotter, work string)) func(t *testing.T) {

--- a/snapshot/testsuite.go
+++ b/snapshot/testsuite.go
@@ -1,0 +1,89 @@
+package snapshot
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/containerd"
+	"github.com/docker/containerd/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// Create a New Layer on top of base layer with Prepare, Stat on new layer, should return Active layer.
+func checkSnapshotterStatActive(t *testing.T, snapshotter Snapshotter, work string) {
+	ctx := context.TODO()
+	preparing := filepath.Join(work, "preparing")
+	if err := os.MkdirAll(preparing, 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	mounts, err := snapshotter.Prepare(ctx, preparing, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mounts) < 1 {
+		t.Fatal("expected mounts to have entries")
+	}
+
+	if err = containerd.MountAll(mounts, preparing); err != nil {
+		t.Fatal(err)
+	}
+	defer testutil.Unmount(t, preparing)
+
+	if err = ioutil.WriteFile(filepath.Join(preparing, "foo"), []byte("foo\n"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	si, err := snapshotter.Stat(ctx, preparing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, si.Name, preparing)
+	assert.Equal(t, KindActive, si.Kind)
+	assert.Equal(t, "", si.Parent)
+}
+
+// Commit a New Layer on top of base layer with Prepare & Commit , Stat on new layer, should return Committed layer.
+func checkSnapshotterStatCommitted(t *testing.T, snapshotter Snapshotter, work string) {
+	ctx := context.TODO()
+	preparing := filepath.Join(work, "preparing")
+	if err := os.MkdirAll(preparing, 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	mounts, err := snapshotter.Prepare(ctx, preparing, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mounts) < 1 {
+		t.Fatal("expected mounts to have entries")
+	}
+
+	if err = containerd.MountAll(mounts, preparing); err != nil {
+		t.Fatal(err)
+	}
+	defer testutil.Unmount(t, preparing)
+
+	if err = ioutil.WriteFile(filepath.Join(preparing, "foo"), []byte("foo\n"), 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	committed := filepath.Join(work, "committed")
+	if err = snapshotter.Commit(ctx, committed, preparing); err != nil {
+		t.Fatal(err)
+	}
+
+	si, err := snapshotter.Stat(ctx, committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, si.Name, committed)
+	assert.Equal(t, KindCommitted, si.Kind)
+	assert.Equal(t, "", si.Parent)
+
+}


### PR DESCRIPTION
Two test cases added
- Prepare, Stat on new layer, should return Active layer.
- Prepare & Commit , Stat on new layer, should return Committed layer

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>