### PR TITLE
cmd/dist: change fetch to fetch-object command

### DIFF
--- a/cmd/dist/delete.go
+++ b/cmd/dist/delete.go
@@ -14,7 +14,7 @@ import (
 
 var deleteCommand = cli.Command{
 	Name:      "delete",
-	Aliases:   []string{"delete", "del", "remove", "rm"},
+	Aliases:   []string{"del", "remove", "rm"},
 	Usage:     "permanently delete one or more blobs.",
 	ArgsUsage: "[flags] [<digest>, ...]",
 	Description: `Delete one or more blobs permanently. Successfully deleted

--- a/cmd/dist/fetchobject.go
+++ b/cmd/dist/fetchobject.go
@@ -25,8 +25,8 @@ import (
 // then receives object/hint lines on stdin, returning content as
 // needed.
 
-var fetchCommand = cli.Command{
-	Name:        "fetch",
+var fetchObjectCommand = cli.Command{
+	Name:        "fetch-object",
 	Usage:       "retrieve objects from a remote",
 	ArgsUsage:   "[flags] <remote> <object> [<hint>, ...]",
 	Description: `Fetch objects by identifier from a remote.`,

--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -61,7 +61,7 @@ distribution tool
 		},
 	}
 	app.Commands = []cli.Command{
-		fetchCommand,
+		fetchObjectCommand,
 		ingestCommand,
 		activeCommand,
 		getCommand,


### PR DESCRIPTION
To allow us to differentiate from fetching an image, fetch a part of an
image and pulling an image, we now call the `fetch` command the
`fetch-object` command. We can now introduce a command that does the
complete image fetch without creating snapshots, allowing `pull` to
perform the entire process.

Signed-off-by: Stephen J Day <stephen.day@docker.com>