### PR TITLE
shim: remove the unused member of the process struct

### DIFF
--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -55,7 +55,6 @@ type process struct {
 	id             string
 	bundle         string
 	stdio          *stdio
-	exec           bool
 	containerPid   int
 	checkpoint     *checkpoint
 	checkpointPath string


### PR DESCRIPTION
Signed-off-by: Wang Long <long.wanglong@huawei.com>