### PR TITLE
Do not read all IO if a container is not started.

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -242,8 +242,6 @@ var runCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		// Ensure we read all io
-		defer fwg.Wait()
 
 		response, err := containers.Create(gocontext.Background(), create)
 		if err != nil {
@@ -254,6 +252,10 @@ var runCommand = cli.Command{
 		}); err != nil {
 			return err
 		}
+
+		// Ensure we read all io only if container started successfully.
+		defer fwg.Wait()
+
 		status, err := waitContainer(events, response)
 		if err != nil {
 			return err


### PR DESCRIPTION
Do not read all IO if a container is not started. There is just nothing to read and it hangs.

Signed-off-by: Volodymyr Burenin <vburenin@gmail.com>