### PR TITLE
Move plugin registration to separate package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 language: go
 
 go:
+  - 1.7.x
   - 1.8.x
   - tip
 

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/containerd/api/types/container"
 	"github.com/docker/containerd/api/types/mount"
 	"github.com/docker/containerd/log"
+	"github.com/docker/containerd/plugin"
 
 	"golang.org/x/net/context"
 )
@@ -24,13 +25,13 @@ const (
 )
 
 func init() {
-	containerd.Register(runtimeName, &containerd.Registration{
-		Type: containerd.RuntimePlugin,
+	plugin.Register(runtimeName, &plugin.Registration{
+		Type: plugin.RuntimePlugin,
 		Init: New,
 	})
 }
 
-func New(ic *containerd.InitContext) (interface{}, error) {
+func New(ic *plugin.InitContext) (interface{}, error) {
 	path := filepath.Join(ic.State, runtimeName)
 	if err := os.MkdirAll(path, 0700); err != nil {
 		return nil, err

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,12 +1,10 @@
-package containerd
+package plugin
 
 import (
 	"fmt"
-	"path/filepath"
-	"plugin"
-	"runtime"
 	"sync"
 
+	"github.com/docker/containerd"
 	"github.com/docker/containerd/content"
 
 	"golang.org/x/net/context"
@@ -29,7 +27,7 @@ type Registration struct {
 type InitContext struct {
 	Root     string
 	State    string
-	Runtimes map[string]Runtime
+	Runtimes map[string]containerd.Runtime
 	Store    *content.Store
 	Config   interface{}
 	Context  context.Context
@@ -72,40 +70,4 @@ func Register(name string, r *Registration) error {
 
 func Registrations() map[string]*Registration {
 	return register.r
-}
-
-// loadPlugins loads all plugins for the OS and Arch
-// that containerd is built for inside the provided path
-func loadPlugins(path string) error {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	pattern := filepath.Join(abs, fmt.Sprintf(
-		"*-%s-%s.%s",
-		runtime.GOOS,
-		runtime.GOARCH,
-		getLibExt(),
-	))
-	libs, err := filepath.Glob(pattern)
-	if err != nil {
-		return err
-	}
-	for _, lib := range libs {
-		if _, err := plugin.Open(lib); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// getLibExt returns a platform specific lib extension for
-// the platform that containerd is running on
-func getLibExt() string {
-	switch runtime.GOOS {
-	case "windows":
-		return "dll"
-	default:
-		return "so"
-	}
 }

--- a/plugin/plugin_go18.go
+++ b/plugin/plugin_go18.go
@@ -1,0 +1,46 @@
+// +build go1.8,!windows
+
+package plugin
+
+import (
+	"fmt"
+	"path/filepath"
+	"plugin"
+	"runtime"
+)
+
+// loadPlugins loads all plugins for the OS and Arch
+// that containerd is built for inside the provided path
+func loadPlugins(path string) error {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	pattern := filepath.Join(abs, fmt.Sprintf(
+		"*-%s-%s.%s",
+		runtime.GOOS,
+		runtime.GOARCH,
+		getLibExt(),
+	))
+	libs, err := filepath.Glob(pattern)
+	if err != nil {
+		return err
+	}
+	for _, lib := range libs {
+		if _, err := plugin.Open(lib); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getLibExt returns a platform specific lib extension for
+// the platform that containerd is running on
+func getLibExt() string {
+	switch runtime.GOOS {
+	case "windows":
+		return "dll"
+	default:
+		return "so"
+	}
+}

--- a/plugin/plugin_other.go
+++ b/plugin/plugin_other.go
@@ -1,0 +1,8 @@
+// +build !go1.8 windows
+
+package plugin
+
+func loadPlugins(path string) error {
+	// plugins not supported until 1.8
+	return nil
+}

--- a/services/content/service.go
+++ b/services/content/service.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/containerd"
 	api "github.com/docker/containerd/api/services/content"
 	"github.com/docker/containerd/content"
 	"github.com/docker/containerd/log"
+	"github.com/docker/containerd/plugin"
 	"github.com/golang/protobuf/ptypes/empty"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -30,13 +30,13 @@ var bufPool = sync.Pool{
 var _ api.ContentServer = &Service{}
 
 func init() {
-	containerd.Register("content-grpc", &containerd.Registration{
-		Type: containerd.GRPCPlugin,
+	plugin.Register("content-grpc", &plugin.Registration{
+		Type: plugin.GRPCPlugin,
 		Init: NewService,
 	})
 }
 
-func NewService(ic *containerd.InitContext) (interface{}, error) {
+func NewService(ic *plugin.InitContext) (interface{}, error) {
 	return &Service{
 		store: ic.Store,
 	}, nil

--- a/services/execution/service.go
+++ b/services/execution/service.go
@@ -7,6 +7,7 @@ import (
 	api "github.com/docker/containerd/api/services/execution"
 	"github.com/docker/containerd/api/types/container"
 	"github.com/docker/containerd/log"
+	"github.com/docker/containerd/plugin"
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -18,13 +19,13 @@ var (
 )
 
 func init() {
-	containerd.Register("runtime-grpc", &containerd.Registration{
-		Type: containerd.GRPCPlugin,
+	plugin.Register("runtime-grpc", &plugin.Registration{
+		Type: plugin.GRPCPlugin,
 		Init: New,
 	})
 }
 
-func New(ic *containerd.InitContext) (interface{}, error) {
+func New(ic *plugin.InitContext) (interface{}, error) {
 	c, err := newCollector(ic.Context, ic.Runtimes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Only compile in plugin support on non-windows go 1.8.
Re-enable go 1.7.x tests in Travis.