### PR TITLE
Runtime configs and global reaper

### DIFF
--- a/cmd/containerd/config.go
+++ b/cmd/containerd/config.go
@@ -58,6 +58,8 @@ func (c *config) decodePlugin(name string, v interface{}) error {
 
 type grpcConfig struct {
 	Socket string `toml:"socket"`
+	Uid    int    `toml:"uid"`
+	Gid    int    `toml:"gid"`
 }
 
 type debug struct {

--- a/cmd/containerd/config.go
+++ b/cmd/containerd/config.go
@@ -44,6 +44,8 @@ type config struct {
 	Snapshotter string `toml:"snapshotter"`
 	// Plugins provides plugin specific configuration for the initialization of a plugin
 	Plugins map[string]toml.Primitive `toml:"plugins"`
+	// Enable containerd as a subreaper
+	Subreaper bool `toml:"subreaper"`
 
 	md toml.MetaData
 }

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/containerd/plugin"
 	"github.com/docker/containerd/reaper"
 	"github.com/docker/containerd/snapshot"
+	"github.com/docker/containerd/sys"
 	"github.com/docker/containerd/utils"
 	metrics "github.com/docker/go-metrics"
 	"github.com/pkg/errors"
@@ -85,6 +86,12 @@ func main() {
 		// we don't miss any signals during boot
 		signals := make(chan os.Signal, 2048)
 		signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT, syscall.SIGUSR1, syscall.SIGCHLD)
+		if conf.Subreaper {
+			log.G(global).Info("setting subreaper...")
+			if err := sys.SetSubreaper(1); err != nil {
+				return err
+			}
+		}
 		log.G(global).Info("starting containerd boot...")
 
 		// load all plugins into containerd

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -330,6 +330,9 @@ func serveGRPC(server *grpc.Server) error {
 	if err != nil {
 		return err
 	}
+	if err := os.Chown(path, conf.GRPC.Uid, conf.GRPC.Gid); err != nil {
+		return err
+	}
 	go func() {
 		defer l.Close()
 		if err := server.Serve(l); err != nil {

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -365,7 +365,7 @@ func handleSignals(signals chan os.Signal, server *grpc.Server) error {
 		log.G(global).WithField("signal", s).Debug("received signal")
 		switch s {
 		case syscall.SIGCHLD:
-			if err := reaper.Reap(); err != nil {
+			if _, err := reaper.Reap(); err != nil {
 				log.G(global).WithError(err).Error("reap containerd processes")
 			}
 		default:

--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -193,11 +193,15 @@ var runCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		abs, err := filepath.Abs(context.String("rootfs"))
+		if err != nil {
+			return err
+		}
 		// for ctr right now just do a bind mount
 		rootfs := []*mount.Mount{
 			{
 				Type:   "bind",
-				Source: context.String("rootfs"),
+				Source: abs,
 				Options: []string{
 					"rw",
 					"rbind",

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -38,7 +38,7 @@ type Config struct {
 	Runtime string `toml:"runtime"`
 }
 
-func New(ic *containerd.InitContext) (interface{}, error) {
+func New(ic *plugin.InitContext) (interface{}, error) {
 	path := filepath.Join(ic.State, runtimeName)
 	if err := os.MkdirAll(path, 0700); err != nil {
 		return nil, err

--- a/linux/shim.go
+++ b/linux/shim.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/docker/containerd/api/services/shim"
+	"github.com/docker/containerd/reaper"
 	"github.com/docker/containerd/utils"
 	"github.com/pkg/errors"
 )
@@ -41,11 +42,9 @@ func newShim(path string) (shim.ShimClient, error) {
 		Cloneflags: syscall.CLONE_NEWNS,
 		Setpgid:    true,
 	}
-	if err := cmd.Start(); err != nil {
+	if err := reaper.Default.Start(cmd); err != nil {
 		return nil, errors.Wrapf(err, "failed to start shim")
 	}
-	// since we are currently the parent go ahead and make sure we wait on the shim
-	go cmd.Wait()
 	return connectShim(socket)
 }
 

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -65,7 +65,6 @@ func (m *Monitor) Start(c *exec.Cmd) error {
 		c:      c,
 		exitCh: make(chan int, 1),
 	}
-	// make sure we register the command first before starting the process
 	m.mu.Lock()
 	// start the process
 	if err := rc.c.Start(); err != nil {
@@ -87,7 +86,9 @@ func (m *Monitor) Run(c *exec.Cmd) error {
 }
 
 func (m *Monitor) Wait(c *exec.Cmd) (int, error) {
+	m.mu.Lock()
 	rc, ok := m.cmds[c.Process.Pid]
+	m.mu.Unlock()
 	if !ok {
 		return 255, fmt.Errorf("process does not exist")
 	}

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -1,0 +1,100 @@
+package reaper
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"sync"
+
+	"github.com/docker/containerd/utils"
+)
+
+// Reap should be called when the process receives an SIGCHLD.  Reap will reap
+// all exited processes and close their wait channels
+func Reap() error {
+	exits, err := utils.Reap(false)
+	for _, e := range exits {
+		Default.mu.Lock()
+		c, ok := Default.cmds[e.Pid]
+		Default.mu.Unlock()
+		if !ok {
+			continue
+		}
+		// after we get an exit, call wait on the go process to make sure all
+		// pipes are closed and finalizers are run on the process
+		c.c.Wait()
+		c.exitCh <- e.Status
+		Default.mu.Lock()
+		delete(Default.cmds, e.Pid)
+		Default.mu.Unlock()
+	}
+	return err
+}
+
+var Default = &Monitor{
+	cmds: make(map[int]*cmd),
+}
+
+type Monitor struct {
+	mu   sync.Mutex
+	cmds map[int]*cmd
+}
+
+func (m *Monitor) Output(c *exec.Cmd) ([]byte, error) {
+	var b bytes.Buffer
+	c.Stdout = &b
+	if err := m.Run(c); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func (m *Monitor) CombinedOutput(c *exec.Cmd) ([]byte, error) {
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+	if err := m.Run(c); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// Start starts the command a registers the process with the reaper
+func (m *Monitor) Start(c *exec.Cmd) error {
+	rc := &cmd{
+		c:      c,
+		exitCh: make(chan int, 1),
+	}
+	// make sure we register the command first before starting the process
+	m.mu.Lock()
+	// start the process
+	if err := rc.c.Start(); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+	m.cmds[rc.c.Process.Pid] = rc
+	m.mu.Unlock()
+	return nil
+}
+
+// Run runs and waits for the command to finish
+func (m *Monitor) Run(c *exec.Cmd) error {
+	if err := m.Start(c); err != nil {
+		return err
+	}
+	_, err := m.Wait(c)
+	return err
+}
+
+func (m *Monitor) Wait(c *exec.Cmd) (int, error) {
+	rc, ok := m.cmds[c.Process.Pid]
+	if !ok {
+		return 255, fmt.Errorf("process does not exist")
+	}
+	return <-rc.exitCh, nil
+}
+
+type cmd struct {
+	c      *exec.Cmd
+	exitCh chan int
+}

--- a/reaper/reaper.go
+++ b/reaper/reaper.go
@@ -11,7 +11,7 @@ import (
 
 // Reap should be called when the process receives an SIGCHLD.  Reap will reap
 // all exited processes and close their wait channels
-func Reap() error {
+func Reap() ([]utils.Exit, error) {
 	exits, err := utils.Reap(false)
 	for _, e := range exits {
 		Default.mu.Lock()
@@ -28,7 +28,7 @@ func Reap() error {
 		delete(Default.cmds, e.Pid)
 		Default.mu.Unlock()
 	}
-	return err
+	return exits, err
 }
 
 var Default = &Monitor{

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,64 +1,32 @@
-# go-runc client for runc; master as of 01/20/2017
-github.com/crosbymichael/go-runc 706de6f422f397fb70b8c98f9b8c8eab2de32ae2
-# console pkg;
+github.com/crosbymichael/go-runc bd9aef7cf4402a3a8728e3ef83dcca6a5a1be899
 github.com/crosbymichael/console 4bf9d88357031b516b3794a2594b6d060a29c59c
-# go-metrics client to prometheus; master as of 12/16/2016
 github.com/docker/go-metrics 0f35294225552d968a13f9c5bc71a3fa44b2eb87
-# prometheus client; latest release as of 12/16/2016
 github.com/prometheus/client_golang v0.8.0
-# prometheus client model; master as of 12/16/2016
 github.com/prometheus/client_model fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-# prometheus common library; master as of 12/16/2016
 github.com/prometheus/common 195bde7883f7c39ea62b0d92ab7359b5327065cb
-# prometheus procfs; master as of 12/16/2016
 github.com/prometheus/procfs fcdb11ccb4389efb1b210b7ffb623ab71c5fdd60
-# beorn7/perks; master as of 12/16/2016
 github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
-# matttproud/golang_protobuf_extensions; latest tagged release as of 12/16/2016
 github.com/matttproud/golang_protobuf_extensions v1.0.0
-# go-units from Docker; latest release as of 12/16/2016
 github.com/docker/go-units v0.3.1
-# gogo/protobuf - master as of 2/15/2016 (latest tagged release doesn't have needed change)
 github.com/gogo/protobuf d2e1ade2d719b78fe5b061b4c18a9f7111b5bdc8
-# golang support for protobufs - master as of 12/16/2016
 github.com/golang/protobuf 8ee79997227bf9b34611aee7946ae64735e6fd93
-# runc, latest release as of 12/16/2016
 github.com/opencontainers/runc ce450bcc6c135cae93ee2a99d41a308c179ff6dc
-# OCI runtime spec, latest release as of 12/16/2016
 github.com/opencontainers/runtime-spec v1.0.0-rc3
-# logrus, latest release as of 12/16/2016
 github.com/Sirupsen/logrus v0.11.0
-# go-btrfs from stevvooe; master as of 1/11/2017
 github.com/stevvooe/go-btrfs 8539a1d04898663b8eda14982e24b74e7a12388e
-# testify go testing support; latest release as of 12/16/2016
 github.com/stretchr/testify v1.1.4
-# go-spew (required by testify, and also by ctr); latest release as of 1/12/2017
 github.com/davecgh/go-spew v1.1.0
-# go-difflib (required by testify); latest release as of 1/12/2017
 github.com/pmezard/go-difflib v1.0.0
-# Go pkg for handling fifos; master as of 12/16/2016
 github.com/tonistiigi/fifo fe870ccf293940774c2b44e23f6c71fff8f7547d
-# client application library; latest release as of 12/16/2016
 github.com/urfave/cli v1.19.1
-# extended Golang net package; upstream reported githash as of 12/16/2016
 golang.org/x/net 8b4af36cd21a1f85a7484b49feb7c79363106d8e
-# Go gRPC support; latest release as of 12/16/2016
 google.golang.org/grpc v1.0.5
-# pkg/errors; latest release as of 12/16/2016
 github.com/pkg/errors v0.8.0
-# lockfile; master as of 1/12/2017
 github.com/nightlyone/lockfile 1d49c987357a327b5b03aa84cbddd582c328615d
-# docker (for docker/pkg/archive, which is required by snapshot); latest experimental release as of 1/12/2017
 github.com/docker/docker v1.13.0-rc6
-# go-digest; master as of 1/12/2017
 github.com/opencontainers/go-digest 21dfd564fd89c944783d00d069f33e3e7123c448
-# sys/unix; master as of 1/12/2017
 golang.org/x/sys/unix d75a52659825e75fff6158388dddc6a5b04f9ba5
-# image-spec master as of 1/17/2017
 github.com/opencontainers/image-spec a431dbcf6a74fca2e0e040b819a836dbe3fb23ca
-# continuity master as of 2/1/2017
 github.com/stevvooe/continuity 1530f13d23b34e2ccaf33881fefecc7e28e3577b
-# sync master as of 12/5/2016
 golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
-
 github.com/BurntSushi/toml      v0.2.0-21-g9906417

--- a/vendor/github.com/crosbymichael/go-runc/monitor.go
+++ b/vendor/github.com/crosbymichael/go-runc/monitor.go
@@ -1,0 +1,50 @@
+package runc
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+var Monitor ProcessMonitor = &defaultMonitor{}
+
+// ProcessMonitor is an interface for process monitoring
+//
+// It allows daemons using go-runc to have a SIGCHLD handler
+// to handle exits without introducing races between the handler
+// and go's exec.Cmd
+// These methods should match the methods exposed by exec.Cmd to provide
+// a consistent experience for the caller
+type ProcessMonitor interface {
+	Output(*exec.Cmd) ([]byte, error)
+	CombinedOutput(*exec.Cmd) ([]byte, error)
+	Run(*exec.Cmd) error
+	Start(*exec.Cmd) error
+	Wait(*exec.Cmd) (int, error)
+}
+
+type defaultMonitor struct {
+}
+
+func (m *defaultMonitor) Output(c *exec.Cmd) ([]byte, error) {
+	return c.Output()
+}
+
+func (m *defaultMonitor) CombinedOutput(c *exec.Cmd) ([]byte, error) {
+	return c.CombinedOutput()
+}
+
+func (m *defaultMonitor) Run(c *exec.Cmd) error {
+	return c.Run()
+}
+
+func (m *defaultMonitor) Start(c *exec.Cmd) error {
+	return c.Start()
+}
+
+func (m *defaultMonitor) Wait(c *exec.Cmd) (int, error) {
+	status, err := c.Process.Wait()
+	if err != nil {
+		return -1, err
+	}
+	return status.Sys().(syscall.WaitStatus).ExitStatus(), nil
+}

--- a/vendor/github.com/crosbymichael/go-runc/utils.go
+++ b/vendor/github.com/crosbymichael/go-runc/utils.go
@@ -1,9 +1,7 @@
 package runc
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os/exec"
 	"strconv"
 	"syscall"
 )
@@ -16,21 +14,6 @@ func ReadPidFile(path string) (int, error) {
 		return -1, err
 	}
 	return strconv.Atoi(string(data))
-}
-
-// runOrError will run the provided command.  If an error is
-// encountered and neither Stdout or Stderr was set the error and the
-// stderr of the command will be returned in the format of <error>:
-// <stderr>
-func runOrError(cmd *exec.Cmd) error {
-	if cmd.Stdout != nil || cmd.Stderr != nil {
-		return cmd.Run()
-	}
-	data, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s: %s", err, data)
-	}
-	return nil
 }
 
 const exitSignalOffset = 128


### PR DESCRIPTION
This has a couple of features in the PR but the main one being that the containerd daemon has a global reaper for handing process exits.  However, unlike before it has full support for waiting on processes created by Go's `exec.Cmd` and integrated into the runc client package.