### PR TITLE
Add `no_shim` config for not running with a shim

### DIFF
--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -372,7 +372,7 @@ func handleSignals(signals chan os.Signal, server *grpc.Server) error {
 		log.G(global).WithField("signal", s).Debug("received signal")
 		switch s {
 		case syscall.SIGCHLD:
-			if _, err := reaper.Reap(); err != nil {
+			if err := reaper.Reap(); err != nil {
 				log.G(global).WithError(err).Error("reap containerd processes")
 			}
 		default:

--- a/linux/runtime.go
+++ b/linux/runtime.go
@@ -36,6 +36,8 @@ func init() {
 type Config struct {
 	// Runtime is a path or name of an OCI runtime used by the shim
 	Runtime string `toml:"runtime"`
+	// NoShim calls runc directly from within the pkg
+	NoShim bool `toml:"no_shim"`
 }
 
 func New(ic *plugin.InitContext) (interface{}, error) {
@@ -50,6 +52,7 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 	c, cancel := context.WithCancel(ic.Context)
 	return &Runtime{
 		root:          path,
+		remote:        !cfg.NoShim,
 		runtime:       cfg.Runtime,
 		events:        make(chan *containerd.Event, 2048),
 		eventsContext: c,
@@ -60,6 +63,7 @@ func New(ic *plugin.InitContext) (interface{}, error) {
 type Runtime struct {
 	root    string
 	runtime string
+	remote  bool
 
 	events        chan *containerd.Event
 	eventsContext context.Context
@@ -71,7 +75,7 @@ func (r *Runtime) Create(ctx context.Context, id string, opts containerd.CreateO
 	if err != nil {
 		return nil, err
 	}
-	s, err := newShim(path)
+	s, err := newShim(path, r.remote)
 	if err != nil {
 		os.RemoveAll(path)
 		return nil, err
@@ -205,7 +209,7 @@ func (r *Runtime) deleteBundle(id string) error {
 
 func (r *Runtime) loadContainer(path string) (*Container, error) {
 	id := filepath.Base(path)
-	s, err := loadShim(path)
+	s, err := loadShim(path, r.remote)
 	if err != nil {
 		return nil, err
 	}

--- a/linux/shim.go
+++ b/linux/shim.go
@@ -14,12 +14,16 @@ import (
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/docker/containerd/api/services/shim"
+	localShim "github.com/docker/containerd/linux/shim"
 	"github.com/docker/containerd/reaper"
 	"github.com/docker/containerd/utils"
 	"github.com/pkg/errors"
 )
 
-func newShim(path string) (shim.ShimClient, error) {
+func newShim(path string, remote bool) (shim.ShimClient, error) {
+	if !remote {
+		return localShim.Client(path), nil
+	}
 	socket := filepath.Join(path, "shim.sock")
 	l, err := utils.CreateUnixSocket(socket)
 	if err != nil {
@@ -48,7 +52,10 @@ func newShim(path string) (shim.ShimClient, error) {
 	return connectShim(socket)
 }
 
-func loadShim(path string) (shim.ShimClient, error) {
+func loadShim(path string, remote bool) (shim.ShimClient, error) {
+	if !remote {
+		return localShim.Client(path), nil
+	}
 	socket := filepath.Join(path, "shim.sock")
 	return connectShim(socket)
 	// TODO: failed to connect to the shim, check if it's alive

--- a/linux/shim/client.go
+++ b/linux/shim/client.go
@@ -1,0 +1,105 @@
+package shim
+
+import (
+	"path/filepath"
+	"syscall"
+
+	shimapi "github.com/docker/containerd/api/services/shim"
+	"github.com/docker/containerd/api/types/container"
+	google_protobuf "github.com/golang/protobuf/ptypes/empty"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func Client(path string) shimapi.ShimClient {
+	return &client{
+		s: New(path),
+	}
+}
+
+type client struct {
+	s *Service
+}
+
+func (c *client) Create(ctx context.Context, in *shimapi.CreateRequest, opts ...grpc.CallOption) (*shimapi.CreateResponse, error) {
+	return c.s.Create(ctx, in)
+}
+
+func (c *client) Start(ctx context.Context, in *shimapi.StartRequest, opts ...grpc.CallOption) (*google_protobuf.Empty, error) {
+	return c.s.Start(ctx, in)
+}
+
+func (c *client) Delete(ctx context.Context, in *shimapi.DeleteRequest, opts ...grpc.CallOption) (*shimapi.DeleteResponse, error) {
+	return c.s.Delete(ctx, in)
+}
+
+func (c *client) Exec(ctx context.Context, in *shimapi.ExecRequest, opts ...grpc.CallOption) (*shimapi.ExecResponse, error) {
+	return c.s.Exec(ctx, in)
+}
+
+func (c *client) Pty(ctx context.Context, in *shimapi.PtyRequest, opts ...grpc.CallOption) (*google_protobuf.Empty, error) {
+	return c.s.Pty(ctx, in)
+}
+
+func (c *client) Events(ctx context.Context, in *shimapi.EventsRequest, opts ...grpc.CallOption) (shimapi.Shim_EventsClient, error) {
+	return &events{
+		c:   c.s.events,
+		ctx: ctx,
+	}, nil
+}
+
+func (c *client) State(ctx context.Context, in *shimapi.StateRequest, opts ...grpc.CallOption) (*shimapi.StateResponse, error) {
+	return c.s.State(ctx, in)
+}
+
+func (c *client) Pause(ctx context.Context, in *shimapi.PauseRequest, opts ...grpc.CallOption) (*google_protobuf.Empty, error) {
+	return c.s.Pause(ctx, in)
+}
+
+func (c *client) Resume(ctx context.Context, in *shimapi.ResumeRequest, opts ...grpc.CallOption) (*google_protobuf.Empty, error) {
+	return c.s.Resume(ctx, in)
+}
+
+func (c *client) Exit(ctx context.Context, in *shimapi.ExitRequest, opts ...grpc.CallOption) (*google_protobuf.Empty, error) {
+	// don't exit the calling process for the client
+	// but make sure we unmount the containers rootfs for this client
+	if err := syscall.Unmount(filepath.Join(c.s.path, "rootfs"), 0); err != nil {
+		return nil, err
+	}
+	return empty, nil
+}
+
+type events struct {
+	c   chan *container.Event
+	ctx context.Context
+}
+
+func (e *events) Recv() (*container.Event, error) {
+	ev := <-e.c
+	return ev, nil
+}
+
+func (e *events) Header() (metadata.MD, error) {
+	return nil, nil
+}
+
+func (e *events) Trailer() metadata.MD {
+	return nil
+}
+
+func (e *events) CloseSend() error {
+	return nil
+}
+
+func (e *events) Context() context.Context {
+	return e.ctx
+}
+
+func (e *events) SendMsg(m interface{}) error {
+	return nil
+}
+
+func (e *events) RecvMsg(m interface{}) error {
+	return nil
+}

--- a/linux/shim/exec.go
+++ b/linux/shim/exec.go
@@ -25,22 +25,19 @@ type execProcess struct {
 	parent *initProcess
 }
 
-func newExecProcess(context context.Context, r *shimapi.ExecRequest, parent *initProcess, id int) (process, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
+func newExecProcess(context context.Context, path string, r *shimapi.ExecRequest, parent *initProcess, id int) (process, error) {
 	e := &execProcess{
 		id:     id,
 		parent: parent,
 	}
 	var (
+		err     error
 		socket  *runc.ConsoleSocket
 		io      runc.IO
-		pidfile = filepath.Join(cwd, fmt.Sprintf("%d.pid", id))
+		pidfile = filepath.Join(path, fmt.Sprintf("%d.pid", id))
 	)
 	if r.Terminal {
-		if socket, err = runc.NewConsoleSocket(filepath.Join(cwd, "pty.sock")); err != nil {
+		if socket, err = runc.NewConsoleSocket(filepath.Join(path, "pty.sock")); err != nil {
 			return nil, err
 		}
 		defer os.Remove(socket.Path())


### PR DESCRIPTION
This reuses the exiting shim code and services to let containerd run as
the reaper for all container processes without the use of a shim.

@ibuildthecloud please take a look, it just uses the grpc service interfaces but keeps the exact same code on both sides, just without a separate process.  I also fixed the global reaper to to introduce races between reaping any processes if containerd is running as an `init`or `subreaper` as well as working with `exec.Cmd` within the codebase.  

Fixes #490

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>