### PR TITLE
use PGID while send SIGTERM signal to process

### DIFF
--- a/runtime/process.go
+++ b/runtime/process.go
@@ -418,7 +418,12 @@ func getControlPipe(path string) (*os.File, error) {
 
 // Signal sends the provided signal to the process
 func (p *process) Signal(s os.Signal) error {
-	return syscall.Kill(p.pid, s.(syscall.Signal))
+	// use PGID while stop process
+        pid := p.pid
+        if s == syscall.SIGTERM {
+            pid = -p.pid
+        }
+        return syscall.Kill(pid, s.(syscall.Signal))
 }
 
 // Start unblocks the associated container init process.


### PR DESCRIPTION
When init process fork some processes, send SIGTERM signal to PGID is better then PID.
example:
```
# docker run --rm -it -d --name ctrtest debian /bin/sh -c "sleep 1000 & sleep 1000"

# docker stop ctrtest # will wait 10 secends, because processes do not stop until timeout, and be killed.
```