### PR TITLE
Remove default value of log-level

### DIFF
--- a/containerd/main.go
+++ b/containerd/main.go
@@ -43,7 +43,6 @@ var daemonFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "log-level",
 		Usage: "Set the logging level [debug, info, warn, error, fatal, panic]",
-		Value: "info",
 	},
 	cli.StringFlag{
 		Name:  "state-dir",


### PR DESCRIPTION
It'll make --debug not work, we removed --debug in
master, but we should keep it for backward compatibility
in 0.2.x.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>