### PR TITLE
Fix rootfs digest computation

### DIFF
--- a/cmd/dist/rootfs.go
+++ b/cmd/dist/rootfs.go
@@ -23,12 +23,12 @@ var rootfsCommand = cli.Command{
 	Name:  "rootfs",
 	Usage: "rootfs setups a rootfs",
 	Subcommands: []cli.Command{
+		rootfsUnpackCommand,
 		rootfsPrepareCommand,
-		rootfsInitCommand,
 	},
 }
 
-var rootfsPrepareCommand = cli.Command{
+var rootfsUnpackCommand = cli.Command{
 	Name:      "unpack",
 	Usage:     "unpack applies layers from a manifest to a snapshot",
 	ArgsUsage: "[flags] <digest>",
@@ -68,7 +68,7 @@ var rootfsPrepareCommand = cli.Command{
 	},
 }
 
-var rootfsInitCommand = cli.Command{
+var rootfsPrepareCommand = cli.Command{
 	Name:      "prepare",
 	Usage:     "prepare gets mount commands for digest",
 	ArgsUsage: "[flags] <digest> <target>",

--- a/rootfs/apply.go
+++ b/rootfs/apply.go
@@ -32,8 +32,6 @@ type Mounter interface {
 //
 // The returned digest is the diffID for the applied layer.
 func ApplyLayer(snapshots snapshot.Snapshotter, mounter Mounter, rd io.Reader, parent digest.Digest) (digest.Digest, error) {
-	digester := digest.Canonical.Digester() // used to calculate diffID.
-	rd = io.TeeReader(rd, digester.Hash())
 	ctx := context.TODO()
 
 	// create a temporary directory to work from, needs to be on same
@@ -67,6 +65,9 @@ func ApplyLayer(snapshots snapshot.Snapshotter, mounter Mounter, rd io.Reader, p
 	if err != nil {
 		return "", err
 	}
+
+	digester := digest.Canonical.Digester() // used to calculate diffID.
+	rd = io.TeeReader(rd, digester.Hash())
 
 	if _, err := archive.Apply(context.Background(), key, rd); err != nil {
 		return "", err

--- a/services/rootfs/preparer.go
+++ b/services/rootfs/preparer.go
@@ -33,7 +33,7 @@ func (rp remoteUnpacker) Unpack(ctx context.Context, layers []ocispec.Descriptor
 	}
 	resp, err := rp.client.Unpack(ctx, &pr)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return resp.ChainID, nil
 }


### PR DESCRIPTION
Compute digest from uncompressed archive. Also properly propagate error on unpack.