### PR TITLE
plugin: disable Go 1.8 plugin on non-amd64

### DIFF
--- a/plugin/plugin_go18.go
+++ b/plugin/plugin_go18.go
@@ -1,4 +1,4 @@
-// +build go1.8,!windows
+// +build go1.8,!windows,amd64
 
 package plugin
 

--- a/plugin/plugin_other.go
+++ b/plugin/plugin_other.go
@@ -1,4 +1,4 @@
-// +build !go1.8 windows
+// +build !go1.8 windows !amd64
 
 package plugin
 


### PR DESCRIPTION
Update https://github.com/docker/containerd/issues/563

Go 1.8 plugin does not work on some architectures such as `arm64`. (https://github.com/golang/go/issues/17138)

So I suggest enabling the plugin only on `amd64` at the moment.
(rather, should we disable it even on amd64, maybe?)

e.g. `Dockerfile` for `arm64`

```dockerfile
FROM dockcross/linux-arm64

RUN apt-get update && apt-get install -y btrfs-tools:arm64
RUN curl -fsSL "https://golang.org/dl/go1.8.linux-amd64.tar.gz" \
        | tar -xzC /usr/local
ENV PATH /go/bin:/usr/local/go/bin:$PATH
ENV GOPATH /go

COPY . /go/src/github.com/docker/containerd
WORKDIR /go/src/github.com/docker/containerd
RUN GOARCH=arm64 CGO_ENABLED=1 make
```

Compilation had been failing without this PR

```
Step 8/8 : RUN GOARCH=arm64 CGO_ENABLED=1 make
 ---> Running in bb3361fed154
🐳 bin/ctr
🐳 bin/containerd
# github.com/docker/containerd/cmd/containerd
/usr/local/go/pkg/tool/linux_amd64/link: running /usr/bin/aarch64-linux-gnu-gcc failed: exit status 1
/usr/lib/gcc/aarch64-linux-gnu/4.9/../../../../aarch64-linux-gnu/bin/ld.gold: internal error in global, at ../../gold/aarch64.cc:4973
collect2: error: ld returned 1 exit status

make: *** [bin/containerd] Error 2
Makefile:108: recipe for target 'bin/containerd' failed
The command '/bin/sh -c GOARCH=arm64 CGO_ENABLED=1 make' returned a non-zero code: 2
```

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>