### PR TITLE
cmd/dist: show real image size in list

### DIFF
--- a/cmd/dist/images.go
+++ b/cmd/dist/images.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"text/tabwriter"
 
+	contentapi "github.com/docker/containerd/api/services/content"
 	"github.com/docker/containerd/images"
+	"github.com/docker/containerd/log"
 	"github.com/docker/containerd/progress"
+	contentservice "github.com/docker/containerd/services/content"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -18,16 +21,25 @@ var imagesCommand = cli.Command{
 	Description: `List images registered with containerd.`,
 	Flags:       []cli.Flag{},
 	Action: func(clicontext *cli.Context) error {
+		var (
+			ctx = background
+		)
+
 		db, err := getDB(clicontext, true)
 		if err != nil {
 			return errors.Wrap(err, "failed to open database")
 		}
-
 		tx, err := db.Begin(false)
 		if err != nil {
 			return errors.Wrap(err, "could not start transaction")
 		}
 		defer tx.Rollback()
+
+		conn, err := connectGRPC(clicontext)
+		if err != nil {
+			return err
+		}
+		provider := contentservice.NewProviderFromClient(contentapi.NewContentClient(conn))
 
 		images, err := images.List(tx)
 		if err != nil {
@@ -37,7 +49,12 @@ var imagesCommand = cli.Command{
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 1, ' ', 0)
 		fmt.Fprintln(tw, "REF\tTYPE\tDIGEST\tSIZE\t")
 		for _, image := range images {
-			fmt.Fprintf(tw, "%v\t%v\t%v\t%v\t\n", image.Name, image.Descriptor.MediaType, image.Descriptor.Digest, progress.Bytes(image.Descriptor.Size))
+			size, err := image.Size(ctx, provider)
+			if err != nil {
+				log.G(ctx).WithError(err).Errorf("failed calculating size for image %s", image.Name)
+			}
+
+			fmt.Fprintf(tw, "%v\t%v\t%v\t%v\t\n", image.Name, image.Descriptor.MediaType, image.Descriptor.Digest, progress.Bytes(size))
 		}
 		tw.Flush()
 

--- a/images/storage.go
+++ b/images/storage.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	errImageUnknown = fmt.Errorf("image: unknown")
-	errNoTx         = fmt.Errorf("no transaction available")
 )
 
 var (


### PR DESCRIPTION
As a demonstration of the power of the visitor implementation, we now
report the image size in the `dist images` command. This is the size of
the packed resources as would be pushed into a remote. A similar method
could be added to calculate the unpacked size.

Signed-off-by: Stephen J Day <stephen.day@docker.com>