### PR TITLE
add nanoseconds to the filename for the checkoints create and restorе filenames to avoid naming collision.

### DIFF
--- a/containerd-shim/process.go
+++ b/containerd-shim/process.go
@@ -137,7 +137,7 @@ func (p *process) create() error {
 		args = append(args, "restore",
 			"-d",
 			"--image-path", p.checkpointPath,
-			"--work-path", filepath.Join(p.checkpointPath, "criu.work", "restore-"+time.Now().Format(time.RFC3339)),
+			"--work-path", filepath.Join(p.checkpointPath, "criu.work", "restore-"+time.Now().Format(time.RFC3339Nano)),
 		)
 		add := func(flags ...string) {
 			args = append(args, flags...)


### PR DESCRIPTION
related to https://github.com/docker/docker/issues/31663

just extended the name to be generated using nanosecond precision to avoid naming collision.


Signed-off-by: Krasi Georgiev <krasi@vip-consult.solutions>