### PR TITLE
ctr: spaces not tabs

### DIFF
--- a/cmd/ctr/main.go
+++ b/cmd/ctr/main.go
@@ -20,7 +20,7 @@ func main() {
 	app.Name = "ctr"
 	app.Version = containerd.Version
 	app.Usage = `
-		__
+        __
   _____/ /______
  / ___/ __/ ___/
 / /__/ /_/ /


### PR DESCRIPTION
the prior use of tabs left the top of point

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>