### PR TITLE
Open stdin write side in shim

### DIFF
--- a/cmd/ctr/run.go
+++ b/cmd/ctr/run.go
@@ -4,6 +4,7 @@ import (
 	gocontext "context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -254,6 +255,7 @@ var runCommand = cli.Command{
 		if err != nil {
 			return err
 		}
+		defer os.RemoveAll(tmpDir)
 		events, err := containers.Events(ctx, &execution.EventsRequest{})
 		if err != nil {
 			return err

--- a/linux/shim/io.go
+++ b/linux/shim/io.go
@@ -68,6 +68,9 @@ func copyPipes(ctx context.Context, rio runc.IO, stdin, stdout, stderr string, w
 		}
 		dest(fw, fr)
 	}
+	if stdin == "" {
+		return nil
+	}
 	f, err := fifo.OpenFifo(ctx, stdin, syscall.O_RDONLY, 0)
 	if err != nil {
 		return fmt.Errorf("containerd-shim: opening %s failed: %s", stdin, err)


### PR DESCRIPTION
This ensures that the stdin fifo always has a write side open in the shim

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>