### PR TITLE
clean up the code in a few places

### DIFF
--- a/archive/compression/compression.go
+++ b/archive/compression/compression.go
@@ -60,7 +60,7 @@ func DetectCompression(source []byte) Compression {
 			// Len too short
 			continue
 		}
-		if bytes.Compare(m, source[:len(m)]) == 0 {
+		if bytes.Equal(m, source[:len(m)]) {
 			return compression
 		}
 	}

--- a/archive/compression/compression_test.go
+++ b/archive/compression/compression_test.go
@@ -53,7 +53,7 @@ func testCompressDecompress(t *testing.T, size int, compression Compression) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Compare(orig, decompressed) != 0 {
+	if !bytes.Equal(orig, decompressed) {
 		t.Fatal("strange decompressed data")
 	}
 }

--- a/archive/tar_linux.go
+++ b/archive/tar_linux.go
@@ -100,10 +100,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 		mode |= syscall.S_IFIFO
 	}
 
-	if err := syscall.Mknod(path, mode, int(mkdev(hdr.Devmajor, hdr.Devminor))); err != nil {
-		return err
-	}
-	return nil
+	return syscall.Mknod(path, mode, int(mkdev(hdr.Devmajor, hdr.Devminor)))
 }
 
 func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {

--- a/cmd/containerd/main.go
+++ b/cmd/containerd/main.go
@@ -137,7 +137,7 @@ func main() {
 		// start the prometheus metrics API for containerd
 		serveMetricsAPI()
 
-		log.G(global).Infof("containerd successfully booted in %fs", time.Now().Sub(start).Seconds())
+		log.G(global).Infof("containerd successfully booted in %fs", time.Since(start).Seconds())
 		return handleSignals(signals, server)
 	}
 

--- a/cmd/ctr/pprof.go
+++ b/cmd/ctr/pprof.go
@@ -49,10 +49,8 @@ var pprofGoroutinesCommand = cli.Command{
 			return err
 		}
 		defer output.Close()
-		if _, err := io.Copy(os.Stdout, output); err != nil {
-			return err
-		}
-		return nil
+		_, err = io.Copy(os.Stdout, output)
+		return err
 	},
 }
 
@@ -67,10 +65,8 @@ var pprofHeapCommand = cli.Command{
 			return err
 		}
 		defer output.Close()
-		if _, err := io.Copy(os.Stdout, output); err != nil {
-			return err
-		}
-		return nil
+		_, err = io.Copy(os.Stdout, output)
+		return err
 	},
 }
 
@@ -85,10 +81,8 @@ var pprofProfileCommand = cli.Command{
 			return err
 		}
 		defer output.Close()
-		if _, err := io.Copy(os.Stdout, output); err != nil {
-			return err
-		}
-		return nil
+		_, err = io.Copy(os.Stdout, output)
+		return err
 	},
 }
 
@@ -112,11 +106,8 @@ var pprofTraceCommand = cli.Command{
 			return err
 		}
 		defer output.Close()
-		if _, err := io.Copy(os.Stdout, output); err != nil {
-			return err
-		}
-		return nil
-
+		_, err = io.Copy(os.Stdout, output)
+		return err
 	},
 }
 
@@ -131,10 +122,8 @@ var pprofBlockCommand = cli.Command{
 			return err
 		}
 		defer output.Close()
-		if _, err := io.Copy(os.Stdout, output); err != nil {
-			return err
-		}
-		return nil
+		_, err = io.Copy(os.Stdout, output)
+		return err
 	},
 }
 
@@ -149,10 +138,8 @@ var pprofThreadcreateCommand = cli.Command{
 			return err
 		}
 		defer output.Close()
-		if _, err := io.Copy(os.Stdout, output); err != nil {
-			return err
-		}
-		return nil
+		_, err = io.Copy(os.Stdout, output)
+		return err
 	},
 }
 

--- a/cmd/dist/fetch.go
+++ b/cmd/dist/fetch.go
@@ -212,11 +212,7 @@ func (j *jobs) jobs() []string {
 	defer j.mu.Unlock()
 
 	var jobs []string
-	for _, j := range j.refs {
-		jobs = append(jobs, j)
-	}
-
-	return jobs
+	return append(jobs, j.refs...)
 }
 
 type statusInfo struct {

--- a/cmd/dist/fetchobject.go
+++ b/cmd/dist/fetchobject.go
@@ -58,10 +58,7 @@ var fetchObjectCommand = cli.Command{
 		}
 		defer rc.Close()
 
-		if _, err := io.Copy(os.Stdout, rc); err != nil {
-			return err
-		}
-
-		return nil
+		_, err = io.Copy(os.Stdout, rc)
+		return err
 	},
 }

--- a/fs/fstest/file.go
+++ b/fs/fstest/file.go
@@ -57,10 +57,7 @@ func RemoveAll(name string) Applier {
 func CreateDir(name string, perm os.FileMode) Applier {
 	return applyFn(func(root string) error {
 		fullPath := filepath.Join(root, name)
-		if err := os.MkdirAll(fullPath, perm); err != nil {
-			return err
-		}
-		return nil
+		return os.MkdirAll(fullPath, perm)
 	})
 }
 

--- a/images/handlers.go
+++ b/images/handlers.go
@@ -137,9 +137,7 @@ func ChildrenHandler(provider content.Provider) HandlerFunc {
 		var descs []ocispec.Descriptor
 
 		descs = append(descs, manifest.Config)
-		for _, desc := range manifest.Layers {
-			descs = append(descs, desc)
-		}
+		descs = append(descs, manifest.Layers...)
 
 		return descs, nil
 	}


### PR DESCRIPTION
This PR makes the following changes:
- removes `if err != nil; return err`; this isn't done to massage the compiler, it's done to clean up the code
- makes the code use bytes.Equal where bytes.Compare was used to check for equality
- changes `time.Now().Sub(start)` to `time.Since(start)`
- removes two redundant for loops where we could simply append