### PR TITLE
cmd/dist, images: allow image delete

### DIFF
--- a/cmd/dist/main.go
+++ b/cmd/dist/main.go
@@ -62,6 +62,7 @@ distribution tool
 	}
 	app.Commands = []cli.Command{
 		imagesCommand,
+		rmiCommand,
 		pullCommand,
 		fetchCommand,
 		fetchObjectCommand,

--- a/cmd/dist/pull.go
+++ b/cmd/dist/pull.go
@@ -67,6 +67,7 @@ command. As part of this process, we do the following:
 
 		ingester := contentservice.NewIngesterFromClient(contentapi.NewContentClient(conn))
 		provider := contentservice.NewProviderFromClient(contentapi.NewContentClient(conn))
+
 		cs, err := resolveContentStore(clicontext)
 		if err != nil {
 			return err

--- a/images/storage.go
+++ b/images/storage.go
@@ -103,6 +103,12 @@ func List(tx *bolt.Tx) ([]Image, error) {
 	return images, nil
 }
 
+func Delete(tx *bolt.Tx, name string) error {
+	return withImagesBucket(tx, func(bkt *bolt.Bucket) error {
+		return bkt.DeleteBucket([]byte(name))
+	})
+}
+
 func readImage(image *Image, bkt *bolt.Bucket) error {
 	return bkt.ForEach(func(k, v []byte) error {
 		if v == nil {


### PR DESCRIPTION
This adds very simple deletion of images by name. We still need to
consider the approach to handling image name, so this may change. For
the time being, it allows one to delete an image entry in the metadata
database.

Signed-off-by: Stephen J Day <stephen.day@docker.com>